### PR TITLE
refactor: re-export BiblatexAPA through BibAPAToHTML (#41)

### DIFF
--- a/Sources/MacDocCLI/CLIHelpers.swift
+++ b/Sources/MacDocCLI/CLIHelpers.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ArgumentParser
 import BibAPAToHTML
-import BiblatexAPA
 
 // MARK: - File Validation
 

--- a/Sources/MacDocCLI/MacDoc+Bib.swift
+++ b/Sources/MacDocCLI/MacDoc+Bib.swift
@@ -3,7 +3,6 @@ import Foundation
 import BibAPAToHTML
 import BibAPAToJSON
 import BibAPAToMD
-import BiblatexAPA
 
 // MARK: - Bib 子命令群
 extension MacDoc {


### PR DESCRIPTION
## Summary
- Add `@_exported import BiblatexAPA` in BibAPAToHTML/Reexports.swift
- Remove direct `import BiblatexAPA` from CLIHelpers.swift and MacDoc+Bib.swift
- CLI now accesses BibParser/BibEntry through the Layer 3 facade, not Layer 1 directly

Closes #41