### PR TITLE
feat: restore pdf-to-md-swift package source and tests

### DIFF
--- a/packages/pdf-to-md-swift/Package.swift
+++ b/packages/pdf-to-md-swift/Package.swift
@@ -16,21 +16,24 @@ let package = Package(
             name: "PDFToMD",
             dependencies: [
                 .product(name: "CommonConverterSwift", package: "common-converter-swift"),
-            ]
+            ],
+            path: "Sources/PDFToMDSwift"
         ),
         .executableTarget(
             name: "PDFToMDSmokeTests",
             dependencies: [
                 "PDFToMD",
                 .product(name: "CommonConverterSwift", package: "common-converter-swift"),
-            ]
+            ],
+            path: "Sources/PDFToMDSwiftSmokeTests"
         ),
         .testTarget(
             name: "PDFToMDTests",
             dependencies: [
                 "PDFToMD",
                 .product(name: "CommonConverterSwift", package: "common-converter-swift"),
-            ]
+            ],
+            path: "Tests/PDFToMDTests"
         ),
     ]
 )

--- a/packages/pdf-to-md-swift/Sources/PDFToMDSwift/PDFConverter.swift
+++ b/packages/pdf-to-md-swift/Sources/PDFToMDSwift/PDFConverter.swift
@@ -1,0 +1,319 @@
+import Foundation
+import PDFKit
+import CommonConverterSwift
+
+public struct PDFConverter: DocumentConverter {
+    public static let sourceFormat = "pdf"
+
+    public init() {}
+
+    public func convert<W: StreamingOutput>(
+        input: URL,
+        output: inout W,
+        options: ConversionOptions
+    ) throws {
+        guard FileManager.default.fileExists(atPath: input.path) else {
+            throw ConversionError.fileNotFound(input.path)
+        }
+        guard let document = PDFDocument(url: input) else {
+            throw ConversionError.invalidDocument("無法開啟 PDF: \(input.lastPathComponent)")
+        }
+
+        if options.includeFrontmatter {
+            try emitFrontmatter(document: document, source: input, output: &output)
+        }
+
+        var emittedPage = false
+        for pageIndex in 0..<document.pageCount {
+            guard let page = document.page(at: pageIndex) else { continue }
+            let pageBlocks = extractBlocks(from: page, options: options)
+            guard !pageBlocks.isEmpty else { continue }
+
+            if emittedPage {
+                try output.writeLine("---")
+                try output.writeBlankLine()
+            }
+
+            for block in pageBlocks {
+                switch block {
+                case .heading(let text):
+                    try output.writeLine("# \(text)")
+                    try output.writeBlankLine()
+                case .paragraph(let text):
+                    try output.writeLine(text)
+                    try output.writeBlankLine()
+                case .unorderedList(let items):
+                    for item in items {
+                        try output.writeLine(item)
+                    }
+                    try output.writeBlankLine()
+                case .orderedList(let items):
+                    for item in items {
+                        try output.writeLine(item)
+                    }
+                    try output.writeBlankLine()
+                }
+            }
+
+            emittedPage = true
+        }
+    }
+
+    private func emitFrontmatter<W: StreamingOutput>(
+        document: PDFDocument,
+        source: URL,
+        output: inout W
+    ) throws {
+        try output.writeLine("---")
+        if let title = document.documentAttributes?[PDFDocumentAttribute.titleAttribute] as? String,
+           !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try output.writeLine("title: \"\(escapeYAML(title))\"")
+        }
+        try output.writeLine("source: \"\(escapeYAML(source.lastPathComponent))\"")
+        try output.writeLine("format: \"pdf\"")
+        try output.writeLine("pages: \(document.pageCount)")
+        try output.writeLine("---")
+        try output.writeBlankLine()
+    }
+
+    private func extractBlocks(from page: PDFPage, options: ConversionOptions) -> [MarkdownBlock] {
+        let lines = extractLineFragments(from: page)
+        guard !lines.isEmpty else { return [] }
+
+        let grouped = groupLinesIntoBlocks(lines)
+        let bodyLineHeight = median(lines.map(\.height))
+
+        return grouped.compactMap { block in
+            classify(block: block, bodyLineHeight: bodyLineHeight, options: options)
+        }
+    }
+
+    private func extractLineFragments(from page: PDFPage) -> [LineFragment] {
+        let bounds = page.bounds(for: .mediaBox)
+        guard let selection = page.selection(for: bounds) else { return [] }
+
+        return selection.selectionsByLine()
+            .compactMap { line in
+                let text = normalizedLine(line.string ?? "")
+                guard !text.isEmpty else { return nil }
+                return LineFragment(
+                    text: text,
+                    minY: line.bounds(for: page).minY,
+                    height: line.bounds(for: page).height,
+                    minX: line.bounds(for: page).minX
+                )
+            }
+            .sorted {
+                if abs($0.minY - $1.minY) > 0.5 {
+                    return $0.minY > $1.minY
+                }
+                return $0.minX < $1.minX
+            }
+    }
+
+    private func groupLinesIntoBlocks(_ lines: [LineFragment]) -> [[LineFragment]] {
+        guard !lines.isEmpty else { return [] }
+        guard lines.count > 1 else { return [lines] }
+
+        let verticalSteps = zip(lines, lines.dropFirst())
+            .map { max(0, $0.0.minY - $0.1.minY) }
+            .filter { $0 > 0 }
+
+        let baseStep = median(verticalSteps)
+        let threshold = max(18, baseStep * 1.6)
+
+        var blocks: [[LineFragment]] = []
+        var current: [LineFragment] = [lines[0]]
+
+        for (previous, currentLine) in zip(lines, lines.dropFirst()) {
+            let delta = max(0, previous.minY - currentLine.minY)
+            if delta > threshold {
+                blocks.append(current)
+                current = [currentLine]
+            } else {
+                current.append(currentLine)
+            }
+        }
+
+        if !current.isEmpty {
+            blocks.append(current)
+        }
+
+        return blocks
+    }
+
+    private func classify(
+        block: [LineFragment],
+        bodyLineHeight: Double,
+        options: ConversionOptions
+    ) -> MarkdownBlock? {
+        let lines = block.map(\.text)
+
+        if let items = parseUnorderedList(lines) {
+            return .unorderedList(items)
+        }
+        if let items = parseOrderedList(lines) {
+            return .orderedList(items)
+        }
+
+        let merged = mergeLines(lines, hardBreaks: options.hardLineBreaks)
+        guard !merged.isEmpty else { return nil }
+
+        let isHeading = block.count == 1
+            && block[0].height > max(bodyLineHeight * 1.15, 18)
+            && looksLikeHeading(merged)
+
+        if isHeading {
+            return .heading(merged)
+        }
+
+        return .paragraph(merged)
+    }
+
+    private func parseUnorderedList(_ lines: [String]) -> [String]? {
+        guard !lines.isEmpty else { return nil }
+
+        var items: [String] = []
+        for line in lines {
+            guard let captures = captureGroups(in: line, pattern: #"^([\t ]*)([•◦▪‣*\-])\s+(.+)$"#), captures.count == 3 else {
+                return nil
+            }
+            let indentLevel = indentationLevel(captures[0])
+            let text = normalizeInlineSpacing(captures[2])
+            guard !text.isEmpty else { return nil }
+            items.append("\(String(repeating: "  ", count: indentLevel))- \(text)")
+        }
+
+        return items
+    }
+
+    private func parseOrderedList(_ lines: [String]) -> [String]? {
+        guard !lines.isEmpty else { return nil }
+
+        var items: [String] = []
+        for line in lines {
+            guard let captures = captureGroups(in: line, pattern: #"^([\t ]*)(\d+)[\.)]\s+(.+)$"#), captures.count == 3 else {
+                return nil
+            }
+            let indentLevel = indentationLevel(captures[0])
+            let ordinal = captures[1]
+            let text = normalizeInlineSpacing(captures[2])
+            guard !text.isEmpty else { return nil }
+            items.append("\(String(repeating: "  ", count: indentLevel))\(ordinal). \(text)")
+        }
+
+        return items
+    }
+
+    private func mergeLines(_ lines: [String], hardBreaks: Bool) -> String {
+        guard let first = lines.first else { return "" }
+
+        var merged = normalizeInlineSpacing(first)
+        for line in lines.dropFirst() {
+            let next = normalizeInlineSpacing(line)
+            guard !next.isEmpty else { continue }
+
+            if merged.hasSuffix("-"), startsWithLowercaseWord(next) {
+                merged.removeLast()
+                merged += next
+            } else if hardBreaks {
+                merged += "  \n" + next
+            } else {
+                merged += " " + next
+            }
+        }
+
+        return merged.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func looksLikeHeading(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard trimmed.count <= 120 else { return false }
+        guard !trimmed.hasSuffix("."), !trimmed.hasSuffix("?"), !trimmed.hasSuffix("!"), !trimmed.hasSuffix(";"), !trimmed.hasSuffix(",") else {
+            return false
+        }
+
+        let words = trimmed.split(whereSeparator: \.isWhitespace)
+        guard (1...12).contains(words.count) else { return false }
+
+        let lowercase = trimmed.lowercased()
+        if lowercase.hasPrefix("chapter ") || lowercase.hasPrefix("section ") || lowercase.hasPrefix("appendix ") {
+            return true
+        }
+
+        return true
+    }
+
+    private func startsWithLowercaseWord(_ text: String) -> Bool {
+        guard let scalar = text.unicodeScalars.first else { return false }
+        return CharacterSet.lowercaseLetters.contains(scalar)
+    }
+
+    private func indentationLevel(_ rawIndent: String) -> Int {
+        let spaces = rawIndent.reduce(into: 0) { partial, character in
+            partial += character == "\t" ? 2 : 1
+        }
+        return max(0, spaces / 2)
+    }
+
+    private func normalizedLine(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func normalizeInlineSpacing(_ text: String) -> String {
+        text.replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+    }
+
+    private func captureGroups(in text: String, pattern: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..., in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range) else {
+            return nil
+        }
+
+        return (1..<match.numberOfRanges).compactMap { index in
+            let range = match.range(at: index)
+            guard let swiftRange = Range(range, in: text) else {
+                return nil
+            }
+            return String(text[swiftRange])
+        }
+    }
+
+    private func median(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    private func escapeYAML(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}
+
+private struct LineFragment {
+    let text: String
+    let minY: Double
+    let height: Double
+    let minX: Double
+}
+
+private enum MarkdownBlock {
+    case heading(String)
+    case paragraph(String)
+    case unorderedList([String])
+    case orderedList([String])
+}

--- a/packages/pdf-to-md-swift/Sources/PDFToMDSwiftSmokeTests/main.swift
+++ b/packages/pdf-to-md-swift/Sources/PDFToMDSwiftSmokeTests/main.swift
@@ -1,0 +1,176 @@
+import Foundation
+import AppKit
+import PDFKit
+import CommonConverterSwift
+import PDFToMD
+
+@main
+struct PDFToMDSwiftSmokeTests {
+    static func main() throws {
+        let runner = Runner()
+        try runner.runAll()
+        print("pdf-to-md smoke tests: OK")
+    }
+}
+
+private struct Runner {
+    private let converter = PDFConverter()
+
+    func runAll() throws {
+        try convertsHeadingParagraphAndBulletList()
+        try convertsOrderedListAndHardBreaks()
+        try insertsPageBreakBetweenPages()
+        try joinsHyphenatedLineBreaks()
+        try frontmatterIncludesSourceAndPageCount()
+    }
+
+    private func convertsHeadingParagraphAndBulletList() throws {
+        let pdf = try makePDF(
+            named: "structure.pdf",
+            pages: [[
+                DrawBlock(text: "Quarterly Results", fontSize: 28, origin: CGPoint(x: 72, y: 700)),
+                DrawBlock(
+                    text: "Revenue increased year over year.\nMargin expansion continued.",
+                    fontSize: 18,
+                    origin: CGPoint(x: 72, y: 300)
+                ),
+                DrawBlock(text: "• Revenue\n• Margin", fontSize: 18, origin: CGPoint(x: 72, y: 140)),
+            ]]
+        )
+        let markdown = try convert(pdf)
+        try expect(markdown.contains("# Quarterly Results"), "missing heading", markdown)
+        try expect(markdown.contains("Revenue increased year over year. Margin expansion continued."), "missing paragraph", markdown)
+        try expect(markdown.contains("- Revenue"), "missing first bullet", markdown)
+        try expect(markdown.contains("- Margin"), "missing second bullet", markdown)
+    }
+
+    private func convertsOrderedListAndHardBreaks() throws {
+        let pdf = try makePDF(
+            named: "ordered-and-breaks.pdf",
+            pages: [[
+                DrawBlock(text: "Line one\nLine two", fontSize: 18, origin: CGPoint(x: 72, y: 560)),
+                DrawBlock(text: "1. Collect data\n2. Review output", fontSize: 18, origin: CGPoint(x: 72, y: 380)),
+            ]]
+        )
+        var options = ConversionOptions.default
+        options.hardLineBreaks = true
+        let markdown = try convert(pdf, options: options)
+        try expect(markdown.contains("Line one  \nLine two"), "missing hard break paragraph", markdown)
+        try expect(markdown.contains("1. Collect data"), "missing ordered item 1", markdown)
+        try expect(markdown.contains("2. Review output"), "missing ordered item 2", markdown)
+    }
+
+    private func insertsPageBreakBetweenPages() throws {
+        let pdf = try makePDF(
+            named: "page-breaks.pdf",
+            pages: [
+                [DrawBlock(text: "Page one paragraph.", fontSize: 18, origin: CGPoint(x: 72, y: 640))],
+                [DrawBlock(text: "Page two paragraph.", fontSize: 18, origin: CGPoint(x: 72, y: 640))],
+            ]
+        )
+        let markdown = try convert(pdf)
+        try expect(markdown.contains("Page one paragraph."), "missing page 1 text", markdown)
+        try expect(markdown.contains("\n---\n\nPage two paragraph."), "missing page break", markdown)
+    }
+
+    private func joinsHyphenatedLineBreaks() throws {
+        let pdf = try makePDF(
+            named: "hyphenation.pdf",
+            pages: [[
+                DrawBlock(text: "micro-\nservice migration", fontSize: 18, origin: CGPoint(x: 72, y: 560)),
+            ]]
+        )
+        let markdown = try convert(pdf)
+        try expect(markdown.contains("microservice migration"), "missing dehyphenated text", markdown)
+        try expect(!markdown.contains("micro- service"), "still contains broken hyphenation", markdown)
+    }
+
+    private func frontmatterIncludesSourceAndPageCount() throws {
+        let pdf = try makePDF(
+            named: "frontmatter.pdf",
+            pages: [[
+                DrawBlock(text: "Frontmatter body.", fontSize: 18, origin: CGPoint(x: 72, y: 640)),
+            ]]
+        )
+        var options = ConversionOptions.default
+        options.includeFrontmatter = true
+        let markdown = try convert(pdf, options: options)
+        try expect(markdown.contains("source: \"frontmatter.pdf\""), "missing frontmatter source", markdown)
+        try expect(markdown.contains("format: \"pdf\""), "missing frontmatter format", markdown)
+        try expect(markdown.contains("pages: 1"), "missing frontmatter page count", markdown)
+    }
+
+    private func expect(_ condition: Bool, _ message: String, _ markdown: String) throws {
+        guard condition else {
+            throw SmokeTestError.failed("\(message)\n--- output ---\n\(markdown)")
+        }
+    }
+
+    private func convert(_ input: URL, options: ConversionOptions = .default) throws -> String {
+        defer { try? FileManager.default.removeItem(at: input.deletingLastPathComponent()) }
+        return try converter.convertToString(input: input, options: options)
+    }
+
+    private func makePDF(named fileName: String, pages: [[DrawBlock]]) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pdf-to-md-smoke-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let url = directory.appendingPathComponent(fileName)
+        let data = NSMutableData()
+        var mediaBox = CGRect(x: 0, y: 0, width: 612, height: 792)
+
+        guard let consumer = CGDataConsumer(data: data as CFMutableData) else {
+            throw SmokeTestError.failed("cannot create PDF consumer")
+        }
+        guard let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
+            throw SmokeTestError.failed("cannot create PDF context")
+        }
+
+        for page in pages {
+            context.beginPDFPage(nil)
+            let graphicsContext = NSGraphicsContext(cgContext: context, flipped: false)
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = graphicsContext
+
+            for block in page {
+                let style = NSMutableParagraphStyle()
+                style.lineSpacing = block.lineSpacing
+                let attributed = NSAttributedString(
+                    string: block.text,
+                    attributes: [
+                        .font: block.font,
+                        .paragraphStyle: style,
+                    ]
+                )
+                if block.text.contains("\n") {
+                    attributed.draw(in: CGRect(x: block.origin.x, y: block.origin.y, width: 468, height: 200))
+                } else {
+                    attributed.draw(at: block.origin)
+                }
+            }
+
+            NSGraphicsContext.restoreGraphicsState()
+            context.endPDFPage()
+        }
+
+        context.closePDF()
+        try Data(referencing: data).write(to: url)
+        return url
+    }
+}
+
+private struct DrawBlock {
+    let text: String
+    let fontSize: CGFloat
+    let origin: CGPoint
+    var lineSpacing: CGFloat = 6
+
+    var font: NSFont {
+        NSFont(name: "Times New Roman", size: fontSize) ?? .systemFont(ofSize: fontSize)
+    }
+}
+
+private enum SmokeTestError: Error {
+    case failed(String)
+}

--- a/packages/pdf-to-md-swift/Tests/PDFToMDTests/PDFConverterTests.swift
+++ b/packages/pdf-to-md-swift/Tests/PDFToMDTests/PDFConverterTests.swift
@@ -1,0 +1,167 @@
+#if canImport(XCTest)
+import XCTest
+import AppKit
+import PDFKit
+import CommonConverterSwift
+@testable import PDFToMD
+
+final class PDFConverterTests: XCTestCase {
+    private let converter = PDFConverter()
+
+    func testConvertsHeadingParagraphAndBulletList() throws {
+        let pdf = try makePDF(
+            named: "structure.pdf",
+            pages: [[
+                DrawBlock(text: "Quarterly Results", fontSize: 28, origin: CGPoint(x: 72, y: 700)),
+                DrawBlock(
+                    text: "Revenue increased year over year.\nMargin expansion continued.",
+                    fontSize: 18,
+                    origin: CGPoint(x: 72, y: 300)
+                ),
+                DrawBlock(text: "• Revenue\n• Margin", fontSize: 18, origin: CGPoint(x: 72, y: 140)),
+            ]]
+        )
+
+        let markdown = try convert(pdf)
+
+        XCTAssert(markdown.contains("# Quarterly Results"), "Got: \(markdown)")
+        XCTAssert(markdown.contains("Revenue increased year over year. Margin expansion continued."), "Got: \(markdown)")
+        XCTAssert(markdown.contains("- Revenue"), "Got: \(markdown)")
+        XCTAssert(markdown.contains("- Margin"), "Got: \(markdown)")
+    }
+
+    func testConvertsOrderedListAndHardBreaks() throws {
+        let pdf = try makePDF(
+            named: "ordered-and-breaks.pdf",
+            pages: [[
+                DrawBlock(text: "Line one\nLine two", fontSize: 18, origin: CGPoint(x: 72, y: 560)),
+                DrawBlock(text: "1. Collect data\n2. Review output", fontSize: 18, origin: CGPoint(x: 72, y: 380)),
+            ]]
+        )
+
+        var options = ConversionOptions.default
+        options.hardLineBreaks = true
+        let markdown = try convert(pdf, options: options)
+
+        XCTAssert(markdown.contains("Line one  \nLine two"), "Got: \(markdown)")
+        XCTAssert(markdown.contains("1. Collect data"), "Got: \(markdown)")
+        XCTAssert(markdown.contains("2. Review output"), "Got: \(markdown)")
+    }
+
+    func testInsertsPageBreakBetweenPages() throws {
+        let pdf = try makePDF(
+            named: "page-breaks.pdf",
+            pages: [
+                [DrawBlock(text: "Page one paragraph.", fontSize: 18, origin: CGPoint(x: 72, y: 640))],
+                [DrawBlock(text: "Page two paragraph.", fontSize: 18, origin: CGPoint(x: 72, y: 640))],
+            ]
+        )
+
+        let markdown = try convert(pdf)
+
+        XCTAssert(markdown.contains("Page one paragraph."), "Got: \(markdown)")
+        XCTAssert(markdown.contains("\n---\n\nPage two paragraph."), "Got: \(markdown)")
+    }
+
+    func testJoinsHyphenatedLineBreaks() throws {
+        let pdf = try makePDF(
+            named: "hyphenation.pdf",
+            pages: [[
+                DrawBlock(text: "micro-\nservice migration", fontSize: 18, origin: CGPoint(x: 72, y: 560)),
+            ]]
+        )
+
+        let markdown = try convert(pdf)
+
+        XCTAssert(markdown.contains("microservice migration"), "Got: \(markdown)")
+        XCTAssertFalse(markdown.contains("micro- service"), "Got: \(markdown)")
+    }
+
+    func testFrontmatterIncludesSourceAndPageCount() throws {
+        let pdf = try makePDF(
+            named: "frontmatter.pdf",
+            pages: [[
+                DrawBlock(text: "Frontmatter body.", fontSize: 18, origin: CGPoint(x: 72, y: 640)),
+            ]]
+        )
+
+        var options = ConversionOptions.default
+        options.includeFrontmatter = true
+        let markdown = try convert(pdf, options: options)
+
+        XCTAssert(markdown.contains("source: \"frontmatter.pdf\""), "Got: \(markdown)")
+        XCTAssert(markdown.contains("format: \"pdf\""), "Got: \(markdown)")
+        XCTAssert(markdown.contains("pages: 1"), "Got: \(markdown)")
+    }
+
+    // MARK: - Helpers
+
+    private func convert(_ input: URL, options: ConversionOptions = .default) throws -> String {
+        defer { try? FileManager.default.removeItem(at: input.deletingLastPathComponent()) }
+        return try converter.convertToString(input: input, options: options)
+    }
+
+    private func makePDF(named fileName: String, pages: [[DrawBlock]]) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pdf-to-md-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let url = directory.appendingPathComponent(fileName)
+        let data = NSMutableData()
+        var mediaBox = CGRect(x: 0, y: 0, width: 612, height: 792)
+
+        guard let consumer = CGDataConsumer(data: data as CFMutableData) else {
+            throw TestError.cannotCreatePDFContext
+        }
+        guard let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
+            throw TestError.cannotCreatePDFContext
+        }
+
+        for page in pages {
+            context.beginPDFPage(nil)
+            let graphicsContext = NSGraphicsContext(cgContext: context, flipped: false)
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = graphicsContext
+
+            for block in page {
+                let style = NSMutableParagraphStyle()
+                style.lineSpacing = block.lineSpacing
+                let attributed = NSAttributedString(
+                    string: block.text,
+                    attributes: [
+                        .font: block.font,
+                        .paragraphStyle: style,
+                    ]
+                )
+                if block.text.contains("\n") {
+                    attributed.draw(in: CGRect(x: block.origin.x, y: block.origin.y, width: 468, height: 200))
+                } else {
+                    attributed.draw(at: block.origin)
+                }
+            }
+
+            NSGraphicsContext.restoreGraphicsState()
+            context.endPDFPage()
+        }
+
+        context.closePDF()
+        try Data(referencing: data).write(to: url)
+        return url
+    }
+}
+
+private struct DrawBlock {
+    let text: String
+    let fontSize: CGFloat
+    let origin: CGPoint
+    var lineSpacing: CGFloat = 6
+
+    var font: NSFont {
+        NSFont(name: "Times New Roman", size: fontSize) ?? .systemFont(ofSize: fontSize)
+    }
+}
+
+private enum TestError: Error {
+    case cannotCreatePDFContext
+}
+#endif


### PR DESCRIPTION
Closes #48

## Summary
- restore the tracked `pdf-to-md-swift` source + tests that were missing from `main`
- wire the current package manifest to the restored source/test paths
- keep package-level smoke + unit coverage for heading/list/page-break/frontmatter behavior

## Test Plan
- `cd packages/pdf-to-md-swift && swift test`
