### PR TITLE
test: Note → PDF/HTML smoke coverage for MacDocCLITests (#81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,6 +409,12 @@ swift run macdoc convert --to md /path/to/test.docx
 swift run macdoc convert --to marker /path/to/test.docx -o /tmp/test_output/
 ```
 
+### `.note` smoke tests (MacDocCLITests)
+
+`Tests/MacDocCLITests/NotePDFConvertTests.swift` 和 `NoteHTMLConvertTests.swift` 跑 `.note` → pdf/html 的端到端 smoke coverage（#81）。兩個 test 透過 `CLITestHelper.noteFixture()` 找 `test-files/*.note` 樣本，找不到就 `XCTSkip` — CI / clean-clone 不會 fail，只會跳過。
+
+若要在本機實際跑 coverage，把任一 `.note` 檔放到 `test-files/`（該目錄被 `.gitignore` 忽略，檔案不會入版控）。committable 小 fixture 是 follow-up（見 #79 討論 serial）。
+
 ## Platform Requirements
 
 - macOS 14+ (macdoc, pdf-to-latex-swift)

--- a/Tests/MacDocCLITests/CLITestHelper.swift
+++ b/Tests/MacDocCLITests/CLITestHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 /// CLI 執行結果
 struct CLIResult {
@@ -69,5 +70,45 @@ enum CLITestHelper {
     static func convert(to format: String, input: String, flags: [String] = []) throws -> CLIResult {
         var args = ["convert", "--to", format] + flags + [input]
         return try run(args)
+    }
+
+    /// 取得 .note 測試 fixture 的絕對路徑。若 repo 內無可用樣本則 XCTSkip。
+    ///
+    /// Phase 1 走 Option B（per #81 diagnosis）：使用 `test-files/*.note` 樣本。
+    /// Clean clone 或 CI 上若無該檔案，測試會被跳過而非失敗 —
+    /// 未來 follow-up 會改成 committable 小 fixture。
+    static func noteFixture(file: StaticString = #filePath, line: UInt = #line) throws -> URL {
+        let candidates = [
+            "test-files/筆記 2026-03-20 15_25_20.note",
+        ]
+
+        for relativePath in candidates {
+            let url = repoRoot.appendingPathComponent(relativePath)
+            if FileManager.default.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+
+        // Fallback: any .note under test-files/. Sort by path to make the pick
+        // deterministic across machines (per logic-review P1: contentsOfDirectory
+        // has undefined order). Distinguish "directory missing" from real I/O
+        // errors so XCTSkip only fires when the directory genuinely isn't there.
+        let fallbackDir = repoRoot.appendingPathComponent("test-files")
+        if FileManager.default.fileExists(atPath: fallbackDir.path) {
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: fallbackDir, includingPropertiesForKeys: nil
+            )
+            let noteFiles = contents
+                .filter { $0.pathExtension.lowercased() == "note" }
+                .sorted(by: { $0.path < $1.path })
+            if let found = noteFiles.first {
+                return found
+            }
+        }
+
+        throw XCTSkip(
+            "No .note fixture found under test-files/. Place a sample .note there to enable Note → PDF/HTML smoke tests. See issue #79 for a committable-fixture follow-up.",
+            file: file, line: line
+        )
     }
 }

--- a/Tests/MacDocCLITests/NoteHTMLConvertTests.swift
+++ b/Tests/MacDocCLITests/NoteHTMLConvertTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+/// Smoke coverage for `macdoc convert --to html file.note`.
+///
+/// Guards against the "#78 refactor passed with zero tests exercising
+/// NoteToHTML" gap flagged by #81. Uses the on-disk `test-files/*.note`
+/// fixture (Option B per #81 diagnosis); skips cleanly when absent.
+final class NoteHTMLConvertTests: XCTestCase {
+
+    func testNoteToHTMLSmoke() throws {
+        let fixture = try CLITestHelper.noteFixture()
+
+        // Note → HTML produces a directory (interactive player with index.html + media/),
+        // not a single file. Use a directory path for --output.
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macdoc-note-html-smoke-\(UUID().uuidString).html")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        // Note → HTML requires --css dark or --css light (per macdoc CLI contract).
+        let result = try CLITestHelper.convert(
+            to: "html",
+            input: fixture.path,
+            flags: ["--output", outputDir.path, "--css", "dark"]
+        )
+
+        XCTAssertEqual(
+            result.exitCode, 0,
+            "macdoc convert --to html SHALL exit 0\nstderr: \(result.stderr)"
+        )
+
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: outputDir.path, isDirectory: &isDirectory),
+            "output SHALL exist at \(outputDir.path)"
+        )
+        XCTAssertTrue(
+            isDirectory.boolValue,
+            "note → html output SHALL be a directory (interactive player with index.html + media/)"
+        )
+
+        let indexURL = outputDir.appendingPathComponent("index.html")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: indexURL.path),
+            "output SHALL include index.html"
+        )
+
+        let content = try String(contentsOf: indexURL, encoding: .utf8)
+        XCTAssertGreaterThan(content.count, 0, "index.html SHALL be non-empty")
+        XCTAssertTrue(
+            content.lowercased().contains("<html"),
+            "index.html SHALL contain an <html tag"
+        )
+    }
+}

--- a/Tests/MacDocCLITests/NotePDFConvertTests.swift
+++ b/Tests/MacDocCLITests/NotePDFConvertTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+import PDFKit
+
+/// Smoke coverage for `macdoc convert --to pdf file.note`.
+///
+/// Guards against the "#78 refactor passed with zero tests exercising
+/// NoteToPDF" gap flagged by #81. Uses the on-disk `test-files/*.note`
+/// fixture (Option B per #81 diagnosis); skips cleanly when absent so
+/// CI / clean-clone builds are not broken by the missing binary blob.
+final class NotePDFConvertTests: XCTestCase {
+
+    private let pdfMagic: [UInt8] = [0x25, 0x50, 0x44, 0x46]  // "%PDF"
+
+    /// Issue body's Expected section requires "Producer string matches expected".
+    /// note-to-pdf-swift renders via CoreGraphics → macOS Quartz PDFContext, so the
+    /// Producer line SHALL contain this substring. Stronger than magic-bytes alone:
+    /// rules out "any 4-byte %PDF stub" and distinguishes macdoc output from an
+    /// arbitrary PDF that happened to land at the output path.
+    private let expectedProducerSubstring = "Quartz PDFContext"
+
+    func testNoteToPDFSmoke() throws {
+        let fixture = try CLITestHelper.noteFixture()
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macdoc-note-pdf-smoke-\(UUID().uuidString).pdf")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let result = try CLITestHelper.convert(
+            to: "pdf",
+            input: fixture.path,
+            flags: ["--output", outputURL.path]
+        )
+
+        XCTAssertEqual(
+            result.exitCode, 0,
+            "macdoc convert --to pdf SHALL exit 0\nstderr: \(result.stderr)"
+        )
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: outputURL.path),
+            "output SHALL exist at \(outputURL.path)"
+        )
+
+        let data = try Data(contentsOf: outputURL)
+        XCTAssertGreaterThanOrEqual(data.count, 4, "output SHALL be non-trivial")
+        XCTAssertEqual(
+            Array(data.prefix(4)), pdfMagic,
+            "output SHALL start with %PDF magic bytes"
+        )
+
+        // Producer assertion — issue body Expected section requirement.
+        guard let pdf = PDFDocument(url: outputURL) else {
+            return XCTFail("output SHALL be a well-formed PDF readable by PDFKit")
+        }
+        let producer = pdf.documentAttributes?[PDFDocumentAttribute.producerAttribute] as? String ?? ""
+        XCTAssertTrue(
+            producer.contains(expectedProducerSubstring),
+            "Producer string SHALL contain '\(expectedProducerSubstring)' (got: '\(producer)')"
+        )
+
+        // Page count floor — guards against the #77 logicalPageHeight regression class
+        // (a single-paragraph .note should produce ≥ 1 rendered page, not zero).
+        XCTAssertGreaterThanOrEqual(
+            pdf.pageCount, 1,
+            "rendered PDF SHALL contain at least one page"
+        )
+    }
+}


### PR DESCRIPTION
Closes #81.

## Scope
Single commit `ae4bab3`: adds end-to-end smoke tests for `macdoc convert --to pdf/html file.note` with defensive assertions (exit 0 + file/directory existence + PDF magic bytes + Producer "Quartz PDFContext" + page count ≥ 1 + HTML <html tag).

## Verification
- `swift test --filter "NotePDFConvertTests|NoteHTMLConvertTests"` → 2/2 green (0.492s)
- Full `swift test` → 28 tests green (26 Swift Testing + 2 XCTest)
- 6-AI ensemble verify (5 Claude + Codex) → PASS after in-scope fixes for Producer/page-count/fixture determinism
- [Verify report](https://github.com/PsychQuant/macdoc/issues/81#issuecomment-4274839830), [closing comment](https://github.com/PsychQuant/macdoc/issues/81#issuecomment-4275375656)

## Files
- `Tests/MacDocCLITests/CLITestHelper.swift` — `noteFixture()` helper with XCTSkip fallback
- `Tests/MacDocCLITests/NotePDFConvertTests.swift` — new, 68 LOC
- `Tests/MacDocCLITests/NoteHTMLConvertTests.swift` — new, 54 LOC
- `CLAUDE.md` — documents the `.note` smoke-tests subsection

Total: 4 files / +169 / -0. Zero production-code change.

## Follow-up
- **#86** — strengthen Note→HTML assertions (media/ dir + size floor) — mirrors the Producer strengthening applied to the PDF path