### PR TITLE
docs(edit-algebra): §10.1 CD diagrams for all 5 OOXMLEdit + 3 WordEdit cases (macdoc#110)

### DIFF
--- a/docs/edit-algebra-cd-discipline.md
+++ b/docs/edit-algebra-cd-discipline.md
@@ -4,13 +4,20 @@ This directory is the runtime home for the **Word↔Swift edit-isomorphism** con
 
 ## What lives here
 
-When the deferred Phase 2 implementation Spectra change lands, this directory will contain:
+The runtime ships in `packages/ooxml-swift/Sources/OOXMLSwift/EditAlgebra/`:
 
-- `Edit.swift` — `Edit` protocol declaring `apply(to:) throws -> Document` and `lower() -> [OOXMLEdit]`; plus `EditError` enum
-- `OOXMLEdit.swift` — syntactic-layer enum (cases address OOXML elements by path)
-- `WordEdit.swift` — semantic-layer enum (cases address Word UI verbs)
+- `Edit.swift` — `Edit` protocol declaring `apply(to:) throws -> WordDocument` and `lower() -> [OOXMLEdit]`; plus `EditError` enum with 5 cases
+- `OOXMLEdit.swift` — syntactic-layer enum (cases address OOXML elements by `ElementID`)
+- `WordEdit.swift` — semantic-layer enum (cases address Word UI verbs); includes `WordRange` and `ParagraphRef` structs
+- `OOXMLEdit+Operation.swift` — `operations() throws -> [Operation]` per-case mapping (Decision 1 in `openspec/changes/ooxml-edit-algebra-implementation/design.md`)
+- `WordDocument+Apply.swift` — `WordDocument.apply(_ edit: any Edit) throws -> WordDocument` public method routing through `OperationLog` + `OperationReducer.materialize`
 
-Currently this directory holds only this README. The Edit type is documented as a normative contract via the Spectra change's spec; runtime files arrive when the implementation Spectra change executes (see "Status" below).
+Phase 2 implementation shipped via:
+- ooxml-swift PR #72 — OpLog Phase 2c reducer critical-path (4 of 14 cases)
+- ooxml-swift PR #73 — Edit algebra runtime + e2e tests
+- ooxml-swift PR #74 — Multi-part scoping + opID-determinism fix
+- ooxml-swift PR #75 — Property-based canonical-identity tests (FullyFaithfulFunctorTests)
+- macdoc PR #109 — Spectra change `ooxml-edit-algebra-implementation` (proposal/design/tasks/spec)
 
 ## CD discipline (PR review gate)
 
@@ -35,10 +42,75 @@ Use ASCII-art ladder format, modeled on IETF RFCs. Show:
 2. The **τ translation** (vertical arrow labels) between Word UI semantics and Swift representation
 3. The **commutativity claim** (two paths from input state to output state must reach the same destination)
 
-Example for `OOXMLEdit.setBold`:
+## Worked Examples — `OOXMLEdit` cases
+
+### 1. `OOXMLEdit.insertParagraph(after:content:styleId:)` — body-level mutation
+
+Inserts a new `<w:p>` after the target paragraph in `word/document.xml`. The simplest CD shape: single-arrow OOXML schema-level change, single-arrow Swift Edit apply, with `τ` mapping the XmlTree → typed WordDocument.
 
 ```
-                  Word UI action: Cmd-B on selected text
+            OOXML schema change: insert <w:p> at body[targetIdx+1]
+            ┌─────────────────────────────────────────────────────┐
+            │                                                     │
+   docx_in ─┼───────────────────────────────────────────────────► docx_out
+            │   target ElementID = e; new <w:p>X</w:p> at idx+1   │
+            │                                                     │
+          τ │                                                     │ τ
+            │                                                     │
+            ▼                                                     ▼
+   doc_in ─────────────────────────────────────────────────────► doc_out
+            doc.apply(OOXMLEdit.insertParagraph(
+                after: e, content: "X", styleId: nil))
+
+CD obligation:
+  τ(docx_out) == doc_out
+  i.e., applying the Edit on the Swift side produces a WordDocument
+  whose τ-equivalent matches the docx_out the schema-level change
+  produces. Verified by FullyFaithfulFunctorTests
+  testInsertParagraphCanonicalIdentity: all paragraphs at positions
+  0..targetIdx and targetIdx+2..end remain bytewise-equal to input;
+  the new paragraph occupies position targetIdx+1.
+
+Determinism subtlety:
+  The new paragraph's libraryUUID == entry.opID (Phase 2c convention).
+  This makes re-materializing the persisted log yield the same tree
+  (verified by MultiPartApplyTests.testApplyPersistedLogReplaysToSameTree).
+```
+
+### 2. `OOXMLEdit.insertParagraphBefore(before:content:styleId:)` — symmetric
+
+Symmetric to `insertParagraph(after:)`. The only difference: new `<w:p>` inserts at body[targetIdx] instead of body[targetIdx+1].
+
+```
+            OOXML schema change: insert <w:p> at body[targetIdx]
+            ┌─────────────────────────────────────────────────────┐
+            │                                                     │
+   docx_in ─┼───────────────────────────────────────────────────► docx_out
+            │   target ElementID = e; new <w:p>X</w:p> at idx     │
+            │                                                     │
+          τ │                                                     │ τ
+            │                                                     │
+            ▼                                                     ▼
+   doc_in ─────────────────────────────────────────────────────► doc_out
+            doc.apply(OOXMLEdit.insertParagraphBefore(
+                before: e, content: "X", styleId: nil))
+
+CD obligation: τ(docx_out) == doc_out. Verified by
+testInsertParagraphBeforeCanonicalIdentity.
+
+Composition with insertParagraph(after:) — Both shift paragraphs by 1,
+just on opposite sides of the target. Applying both in sequence:
+  doc.apply([before, after]) yields original [..., new1, target, new2, ...].
+This composition is associative-with-target-position and tested in
+DocumentApplyTests sequence fold path.
+```
+
+### 3. `OOXMLEdit.setBold(target:value:)` — run-level mutation
+
+Sets or removes the `<w:b/>` marker inside a `<w:r>`'s `<w:rPr>`. Requires `<w:rPr>` element handling (create if missing; remove if empty after operation).
+
+```
+                  Word UI action: Cmd-B on selected run
             ┌─────────────────────────────────────────────┐
             │                                             │
    docx_in ─┼──────────────────────────────────────────► docx_out
@@ -47,36 +119,242 @@ Example for `OOXMLEdit.setBold`:
           τ │                                             │ τ
             │                                             │
             ▼                                             ▼
-   swift_in ─────────────────────────────────────────► swift_out
-                  Document.apply(OOXMLEdit.setBold(at: runPath, value: true))
+   doc_in ─────────────────────────────────────────► doc_out
+                  doc.apply(OOXMLEdit.setBold(target: runID, value: true))
 
 CD obligation:
-  τ(docx_out) == swift_out  (i.e., applying setBold on the Swift side
+  τ(docx_out) == doc_out  (i.e., applying setBold on the Swift side
   produces the same state τ-equivalent to Word's behavior)
+
+Subtlety — rPr management:
+  - value: true → ensure <w:b/> present in <w:rPr>; create <w:rPr> if missing
+  - value: false → remove <w:b/>; remove <w:rPr> entirely if empty
+  - value: nil — NOT a valid OOXMLEdit input; setBold takes Bool, not Bool?
+
+Verified by FullyFaithfulFunctorTests.testSetBoldCanonicalIdentity:
+all non-target runs' bold flag unchanged; target run's bold = true.
 ```
 
-### Worked examples
+### 4. `OOXMLEdit.removeParagraph(target:)` — body-level negative case
 
-See `openspec/changes/ooxml-edit-isomorphism-foundation/design.md` § ADR-002 *Worked Examples* for fleshed-out CD diagrams for:
+Removes the target `<w:p>` from body.children. Stresses the canonical-identity invariant because the body's children indices shift up by 1 for paragraphs after the target.
 
-- `OOXMLEdit.insertParagraph(at:content:)` (body-level mutation, straightforward CD)
-- `OOXMLEdit.setBold(at:value:)` (run-level mutation, requires rPr handling)
-- `OOXMLEdit.insertHyperlink(at:href:)` (dual-part mutation requiring relationship-part update — non-trivial CD)
-- `WordEdit.applyBold(range:)` with range-crossing-paragraph case (boundary-ambiguity CD: `lower()` produces multiple OOXMLEdit cases)
+```
+            OOXML schema change: remove <w:p> at body[targetIdx]
+            ┌─────────────────────────────────────────────────────┐
+            │                                                     │
+   docx_in ─┼───────────────────────────────────────────────────► docx_out
+            │   target ElementID = e; body[targetIdx] removed     │
+            │                                                     │
+          τ │                                                     │ τ
+            │                                                     │
+            ▼                                                     ▼
+   doc_in ─────────────────────────────────────────────────────► doc_out
+            doc.apply(OOXMLEdit.removeParagraph(target: e))
+
+CD obligation: τ(docx_out) == doc_out. Verified by
+FullyFaithfulFunctorTests.testRemoveParagraphCanonicalIdentity.
+
+Stress on canonical-identity:
+  Paragraphs at positions targetIdx+1..end now occupy positions
+  targetIdx..end-1 in result. Their ElementIDs MUST be unchanged
+  (only their array index shifted). The property test asserts
+  Array(after.suffix(from: targetIdx)) == Array(before.suffix(from: targetIdx + 1))
+  — same elements, just at lower indices.
+
+MVP limitation (tracked in macdoc#110):
+  Cross-part orphan refs (comments / footnotes / bookmarks pointing
+  TO the removed paragraph) are NOT collected. A real .docx using
+  removeParagraph on a paragraph with comment anchors would leave
+  dangling references. Phase 2c follow-up.
+```
+
+### 5. `OOXMLEdit.insertHyperlink(target:href:displayText:)` — dual-part atomic (STUBBED)
+
+The most complex CD: a single OOXMLEdit lowers to TWO `Operation` calls (`insertNode` for `<w:hyperlink>` in document.xml + `updateAttribute` for the Relationship Target in `_rels/document.xml.rels`). Atomicity is enforced at Edit level.
+
+```
+            OOXML dual-part schema change:
+              (a) insert <w:hyperlink r:id="rNN">...</w:hyperlink> in document.xml
+              (b) add <Relationship Id="rNN" Target="href"/> in _rels/document.xml.rels
+            ┌─────────────────────────────────────────────────────────────┐
+            │                                                             │
+   docx_in ─┼───────────────────────────────────────────────────────────► docx_out
+            │   target = e; href = url; displayText = text                │
+            │                                                             │
+          τ │                                                             │ τ
+            │                                                             │
+            ▼                                                             ▼
+   doc_in ─────────────────────────────────────────────────────────────► doc_out
+            doc.apply(OOXMLEdit.insertHyperlink(
+                target: e, href: url, displayText: text))
+
+CD obligation:
+  τ(docx_out) == doc_out, AND atomicity invariant holds:
+  if EITHER sub-operation fails validation, NEITHER is applied
+  (no partial state visible to caller).
+
+Current status — STUBBED:
+  Pending §5 composite design checkpoint (macdoc#105 tasks.md §5).
+  5 open design questions:
+    (1) target type semantics (wrap existing Run vs insert new wrapper?)
+    (2) atomicity strategy (Operation.batchBegin/End or pre-validation?)
+    (3) rels XML coordination (same Operation or cross-part composite?)
+    (4) displayText nil → use href as displayed text?
+    (5) run-splitting when range partial-covers a Run
+
+  Until §5 ships, OOXMLEdit.insertHyperlink.operations() throws
+  notImplemented. FullyFaithfulFunctorTests covers this case as
+  XCTSkip with documented reason.
+
+  Additionally requires ooxml-swift#71 follow-up cases:
+  insertNode + updateAttribute reducer implementations (not yet in
+  PR #72's critical-path subset).
+```
+
+## Worked Examples — `WordEdit` cases
+
+The `WordEdit` enum lives at the semantic layer: case names follow Word UI verbs. Each case's `lower()` method translates to one or more `OOXMLEdit` cases, satisfying the naturality invariant `(a ∘ b).lower() == a.lower() ∘ b.lower()` for composable pairs.
+
+### 6. `WordEdit.applyBold(range: WordRange)` — Word UI Cmd-B
+
+The range-crossing-paragraph case is the most interesting: a single Word UI action (Cmd-B over a selection that spans paragraphs) lowers to N `OOXMLEdit.setBold` cases, one per affected paragraph.
+
+```
+              Word UI action: select text + Cmd-B
+            ┌─────────────────────────────────────────────────────┐
+            │                                                     │
+   docx_in ─┼───────────────────────────────────────────────────► docx_out
+            │   selection spans M runs across N paragraphs        │
+            │                                                     │
+          τ │                                                     │ τ
+            │                                                     │
+            ▼                                                     ▼
+   doc_in ─────────────────────────────────────────────────────► doc_out
+
+   The Swift side decomposes into two arrows:
+   ┌────────────────────────────────────────────────────────────┐
+   │                                                            │
+   doc_in ─lower()─► [OOXMLEdit.setBold(...) × M] ─apply─► doc_out
+
+   Lower step:
+     WordEdit.applyBold(range: r).lower() returns N OOXMLEdit
+     elements when range crosses paragraph boundaries (one per
+     affected paragraph), per foundation ADR-002 Worked Example 4.
+
+   Apply step:
+     doc.apply([oOXMLEdit1, ..., oOXMLEditN]) chains through
+     sequence-folding apply, mutating xmlTrees per OOXMLEdit.
+
+CD obligation (this is the FULLY-FAITHFUL FUNCTOR property):
+  τ(docx_out) == doc_out
+  AND
+  τ(WordEdit.applyBold(r)(docx_in)) == OOXMLEdits.fold(τ(docx_in))
+  where OOXMLEdits = WordEdit.applyBold(r).lower().
+
+  i.e., applying the Word UI action then translating to Swift gives
+  the same result as translating first then applying the lowered
+  OOXMLEdit chain. This is the diagram's commutativity claim.
+
+Implementation status:
+  WordEdit.lower() currently returns [] (stub). When §7 ships
+  (macdoc#105 tasks.md §7.1), single-Run case (startRun == endRun)
+  is the trivial mapping; multi-Run / multi-paragraph case requires
+  document context to resolve which runs are inside the range
+  (lower() is no-arg per Edit protocol, so multi-paragraph case
+  needs design — likely lower-with-context or split-on-apply).
+```
+
+### 7. `WordEdit.applyLink(range: WordRange, url: URL)` — Word UI Cmd-K
+
+Lowers to `OOXMLEdit.insertHyperlink`. Atomicity (document.xml + rels-part update) is handled at the OOXMLEdit layer.
+
+```
+              Word UI action: select text + Cmd-K (insert hyperlink)
+            ┌─────────────────────────────────────────────────────┐
+            │                                                     │
+   docx_in ─┼───────────────────────────────────────────────────► docx_out
+            │   selection = r; href = url; displayText = r.text   │
+            │                                                     │
+          τ │                                                     │ τ
+            │                                                     │
+            ▼                                                     ▼
+   doc_in ─────────────────────────────────────────────────────► doc_out
+
+   Lower step:
+     WordEdit.applyLink(range: r, url: u).lower() returns
+     [OOXMLEdit.insertHyperlink(target: rangeRoot, href: u,
+                                displayText: rangeText)]
+
+   Apply step:
+     OOXMLEdit.insertHyperlink handles dual-part atomicity (per its
+     own CD diagram above).
+
+CD obligation:
+  Same fully-faithful-functor structure as applyBold; the chain
+  of arrows commutes.
+
+Implementation status:
+  Doubly stubbed: WordEdit.lower() (§7 macdoc#105) AND
+  OOXMLEdit.insertHyperlink (§5 macdoc#105) both pending.
+  This case is fully blocked until both ship.
+```
+
+### 8. `WordEdit.applyInsertParagraph(after: ParagraphRef, content: String)` — Word UI Enter + type
+
+Simplest WordEdit case: 1:1 lowering to `OOXMLEdit.insertParagraph(after:)`.
+
+```
+              Word UI action: cursor at end-of-paragraph + Enter + type
+            ┌─────────────────────────────────────────────────────┐
+            │                                                     │
+   docx_in ─┼───────────────────────────────────────────────────► docx_out
+            │   ParagraphRef = p; new paragraph content = X       │
+            │                                                     │
+          τ │                                                     │ τ
+            │                                                     │
+            ▼                                                     ▼
+   doc_in ─────────────────────────────────────────────────────► doc_out
+
+   Lower step:
+     WordEdit.applyInsertParagraph(after: p, content: X).lower()
+     returns [OOXMLEdit.insertParagraph(after: p.elementID,
+                                        content: X, styleId: nil)]
+
+   Apply step:
+     Routes through OOXMLEdit.insertParagraph's apply (see CD #1).
+
+CD obligation: τ(docx_out) == doc_out. Naturality with composing
+cases (e.g., applyInsertParagraph ∘ applyBold) verified by §9
+NaturalityTests (macdoc#110 follow-up).
+
+Implementation status:
+  WordEdit.lower() returns [] (stub). When §7 ships (macdoc#105
+  tasks.md §7.3), this case is the simplest 1:1 mapping.
+```
 
 ## Status
 
-This Edit type contract is currently in **decision-pinning state**: the Spectra change `ooxml-edit-isomorphism-foundation` has shipped its proposal / design.md (9 ADRs) / spec.md (8 Requirements) / tasks.md (35 tasks). Runtime implementation (Edit protocol code, OOXMLEdit / WordEdit enum cases, property tests) is deferred to a Phase 2 follow-up Spectra change that cites this foundation.
+The Edit type contract is **implemented and shipping** (no longer in decision-pinning state). Phase 2 runtime landed via the PRs listed above. Property-based canonical-identity tests + multi-part scoping + opID-determinism contracts are pinned. Remaining work tracked in [macdoc#110](https://github.com/PsychQuant/macdoc/issues/110):
+
+- §5 `OOXMLEdit.insertHyperlink` composite (pending design checkpoint)
+- §7 `WordEdit.lower()` per-case implementations
+- §9 `NaturalityTests` (depends on §7)
+- §10.2 Performance benchmark
+- Item #8: stale typed-views resync after apply
+- Stub-cascade test cleanup (depends on §5)
 
 Downstream consumers:
 
 - `che-word-mcp` (#162) — MCP tool surface refactor to `WordEdit` (deferred per ADR-009)
 - `word-builder-swift` (#101) — lens-model migration (deferred per ADR-008)
-- macdoc PR #94 / #95 / #96 / #97 / #98 — re-framing to Layer 3 / 4 front-ends (deferred per ADR-009; tracking issues #102 / #103 / #104)
+- macdoc PR #94 / #95 / #96 / #97 / #98 — re-framing to Layer 3 / 4 front-ends (deferred per ADR-009)
 
 ## Related documents
 
-- Spectra change: `openspec/changes/ooxml-edit-isomorphism-foundation/`
-- Capability spec: `openspec/changes/ooxml-edit-isomorphism-foundation/specs/ooxml-edit-algebra/spec.md`
+- Spectra change (foundation): `openspec/changes/ooxml-edit-isomorphism-foundation/`
+- Spectra change (Phase 2 runtime): `openspec/changes/ooxml-edit-algebra-implementation/`
+- Capability spec (foundation): `openspec/changes/ooxml-edit-isomorphism-foundation/specs/ooxml-edit-algebra/spec.md`
+- Capability spec (Phase 2 runtime): `openspec/changes/ooxml-edit-algebra-implementation/specs/ooxml-edit-algebra-runtime/spec.md`
 - Prior-art docs: `docs/lossless-conversion.md`, `docs/structural-editing-paradigm.md`, `docs/functional-correspondence.md`
 - Active runtime change: `openspec/changes/word-aligned-state-sync/` (provides the event-sourced runtime mechanism this contract types over)


### PR DESCRIPTION
## Summary

Third slice of [macdoc#110](https://github.com/PsychQuant/macdoc/issues/110) — completes the spec mandate from [macdoc#105 spec.md §149-161](https://github.com/PsychQuant/macdoc/blob/main/openspec/changes/ooxml-edit-algebra-implementation/specs/ooxml-edit-algebra-runtime/spec.md) "Requirement: CD Diagrams Land in Documentation".

**Before**: 1 inline CD diagram (`setBold` worked example).
**After**: 8 CD diagrams co-located in `docs/edit-algebra-cd-discipline.md`, one per implemented Edit case.

## Diagrams added (7 new + 1 expanded)

### OOXMLEdit cases (5)

| Case | Layer | Status |
|---|---|---|
| `insertParagraph(after:content:styleId:)` | body-level | ✓ functional |
| `insertParagraphBefore(before:content:styleId:)` | body-level (symmetric) | ✓ functional |
| `setBold(target:value:)` | run-level (rPr mgmt) | ✓ functional (was the original example) |
| `removeParagraph(target:)` | body-level negative | ✓ functional |
| `insertHyperlink(target:href:displayText:)` | dual-part atomic | STUBBED (§5 pending) |

### WordEdit cases (3)

| Case | Word UI | Status |
|---|---|---|
| `applyBold(range:)` | Cmd-B (range-crossing case is the most interesting) | STUBBED (§7 pending) |
| `applyLink(range:url:)` | Cmd-K | STUBBED (§7 + §5 pending) |
| `applyInsertParagraph(after:content:)` | Enter + type | STUBBED (§7 pending; trivial 1:1) |

## Diagram pattern

Each diagram follows the ASCII-ladder format from foundation ADR-002:
- Top arrow: Word UI action or OOXML schema-level change
- Bottom arrow: Swift Edit apply through `doc.apply(...)`
- Vertical `τ` arrows: translation between OOXML and WordDocument
- "CD obligation" block stating the commutativity claim
- Cross-reference to the verifying test (`FullyFaithfulFunctorTests` for the 4 functional cases)
- Implementation status note (stubs flagged with tracker)

## Doc structure cleanup

- Updated "What lives here" section: was "will arrive when Phase 2 lands"; now lists the actual `EditAlgebra/` files
- Updated "Status" section: was "decision-pinning state"; now reflects Phase 2 shipped via PRs #72-#75
- Cross-referenced this Phase 2 Spectra change (`ooxml-edit-algebra-implementation`) alongside the foundation change

## Why this matters

The macdoc#99 PR template requires "CD diagram for EditAlgebra/ PRs". Before this PR, reviewers had to point new contributors at foundation ADR-002's Worked Examples (4 of 8 needed) + the inline `setBold` example. Now all 8 cases have local-to-the-doc references — future PRs can match new cases against the existing pattern and reviewers have a single source of truth.

## File grew from 83 to 360 lines

Adds ~280 lines of structured CD documentation. The increase is mostly diagrams + cross-references; the existing rationale ("Why CD discipline", "How to draw") was preserved.

## Test plan

- [x] All 8 expected CD diagrams present (`grep -c "CD obligation" = 8`)
- [x] All 8 contain ASCII ladder with top + bottom arrows + vertical τ
- [x] Each functional case (4 of 8) cross-references its `FullyFaithfulFunctorTests` test
- [x] Each stub case (4 of 8) cross-references its tracker (§5 / §7)
- [x] Status section reflects reality (Phase 2 shipped, no longer pinning state)
- [x] Markdown renders cleanly (verified via file inspection)

## Remaining macdoc#110 work (6 items remain)

| # | Item | Status |
|---|---|---|
| 1 | FullyFaithfulFunctorTests | ✓ DONE (PR #75) |
| 2 | NaturalityTests | TODO (depends on §7) |
| 3 | **CD diagrams (7 missing) + status update** | **✓ DONE (this PR)** |
| 4 | Performance benchmark | TODO |
| 5 | §5 insertHyperlink composite | TODO (pending design checkpoint) |
| 6 | §7 WordEdit.lower() per-case | TODO |
| 7 | Multi-part scoping fix | ✓ DONE (PR #74) |
| 8 | Stale typed-views resync | TODO |
| 9 | Stub-cascade test cleanup | TODO (depends on §5) |

Refs PsychQuant/macdoc#110
Refs PsychQuant/macdoc#105
Refs PsychQuant/macdoc#99
