### PR TITLE
Replace hardcoded local source path with GitHub URL in macdoc SKILL.md

### DIFF
--- a/plugins/macdoc/skills/macdoc/SKILL.md
+++ b/plugins/macdoc/skills/macdoc/SKILL.md
@@ -11,7 +11,7 @@ description: |
 # macdoc — macOS 原生文件處理 CLI
 
 安裝位置：`~/bin/macdoc`（或 `/usr/local/bin/macdoc`）
-原始碼：`/Users/che/Developer/macdoc`
+原始碼：https://github.com/PsychQuant/macdoc
 
 ## 子命令總覽
 


### PR DESCRIPTION
Refs #113

## Summary
`plugins/macdoc/skills/macdoc/SKILL.md:14` 開發機絕對路徑 → `https://github.com/PsychQuant/macdoc`（全 plugin grep 驗證無殘留）。

## Verification
Codex（gpt-5.5 xhigh）verify PASS — 詳見 issue #113 Verify comment。

## Checklist
- [x] Diagnose
- [x] Implement (1 commit)
- [x] Verify PASS
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize (manual gate; no auto-close trailer)

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves).
