### PR TITLE
spec: consolidate operation taxonomy — single normative home + OOXML-mirror naming

### DIFF
--- a/openspec/changes/word-aligned-state-sync/design.md
+++ b/openspec/changes/word-aligned-state-sync/design.md
@@ -179,6 +179,8 @@ The Phase 4 script transcoder (`ooxml-script-transcode` capability — `ScriptEx
 - `docs/swift-as-document-source.md` — narrative DSL design rationale
 - `packages/ooxml-swift/Sources/WordDSLSwift/` — placeholder Swift files Phase 4 fills in
 
+**Taxonomy alignment note (#128, 2026-07-05)**: the operation wire format's single normative home is `ooxml-operation-log`; this change's `ooxml-operation-log` delta adds the authoring ops (`appendParagraph(in:)`, `setRuns`, `defineStyle`, `beginComponent`/`endComponent`, inline atoms) with OOXML-mirror (ECMA-376) naming per user decision on #128. `mdocx-grammar`'s SBE op names are references to that taxonomy (MODIFIED delta in this change normalizes them); `ooxml-script-transcode`'s pre-mdocx draft scenarios were rewritten to the mdocx surface. Phase 4 implementation consumes the canonical taxonomy only.
+
 **Phase numbering note**: Several artifacts written before `mdocx-syntax` archived (the now-canonical `mdocx-grammar` spec, Swift placeholder file headers, ad-hoc memory notes) refer to "Phase 7" as the DSL implementation phase. That is stale wording from an earlier 9-phase draft. Canonical phase numbering is the one in `tasks.md` of this change (Phase 0–5); the DSL implementation is **Phase 4 — Script transcoder, target v0.34.0**. References to "Phase 7" elsewhere should be read as "Phase 4 of word-aligned-state-sync."
 
 ## Risks / Trade-offs

--- a/openspec/changes/word-aligned-state-sync/specs/mdocx-grammar/spec.md
+++ b/openspec/changes/word-aligned-state-sync/specs/mdocx-grammar/spec.md
@@ -47,6 +47,8 @@ Tab stops (`Tab()`), line breaks (`Break()`), no-break hyphens (`NoBreakHyphen()
 
 | Source | Emitted op (canonical, per `ooxml-operation-log`) |
 | ------ | ------------------------------------------------- |
-| `Tab()` | `insertTab(in: <container-id>)` — appended in declaration order |
-| `Break()` | `insertBreak(in: <container-id>)` |
-| `NoBreakHyphen()` | `insertNoBreakHyphen(in: <container-id>)` |
+| `Tab()` | `insertTab(in: <run-id>)` — appended in declaration order |
+| `Break()` | `insertBreak(in: <run-id>)` |
+| `NoBreakHyphen()` | `insertNoBreakHyphen(in: <run-id>)` |
+
+`in:` addresses a run (`<w:r>`) — atoms are only schema-valid inside runs. A standalone atom with no preceding run in the paragraph causes the reducer to synthesize an empty wrapping `<w:r>` (rule pinned in `ooxml-operation-log`).

--- a/openspec/changes/word-aligned-state-sync/specs/mdocx-grammar/spec.md
+++ b/openspec/changes/word-aligned-state-sync/specs/mdocx-grammar/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Operation wire format is defined by ooxml-operation-log
+
+The op names appearing in this spec's Scenarios and SBE Examples SHALL be read as references to the canonical operation taxonomy defined in `ooxml-operation-log` — the single normative home of the operation wire format (#128). This spec regulates the DSL surface and the reverse transcoder's behavior; it SHALL NOT define or restate operation shapes. Where an example historically showed a positional `at:` index, the index is derived display metadata: actual addressing is ID-based per `ooxml-operation-log`'s "ID-based operations, never positional indices" requirement — the DSL emits children in declaration order via `appendParagraph(in:)` / `insertParagraphAfter(after:)` anchoring.
+
+#### Scenario: Example op names resolve to canonical taxonomy
+
+- **WHEN** an SBE example in this spec names an emitted operation
+- **THEN** the operation's authoritative shape (payload fields, addressing, JSONL form) is the one in `ooxml-operation-log`, and any discrepancy resolves in favor of `ooxml-operation-log`
+
+## MODIFIED Requirements
+
+### Requirement: Component-aware op log via BeginComponent and EndComponent
+
+A user-defined type conforming to `WordComponent` MUST emit a paired `beginComponent` and `endComponent` operation (canonical shapes in `ooxml-operation-log`) bracketing all operations produced by its body. The `beginComponent` op MUST carry the component's runtime type name and its `id`; the `endComponent` op MUST carry the same `id`.
+
+The reverse transcoder MUST recognise the `beginComponent`/`endComponent` envelope in the op log and reconstruct the component invocation in the output source. The `beginComponent` and `endComponent` operations MUST NOT produce any element in the final OOXML output (they are op-log metadata only — the documented exception to OOXML-mirror op naming).
+
+#### Scenario: component body wrapped in op-log envelope
+
+- **GIVEN** a custom component `Summary` that, when expanded, produces one `Paragraph(id: "sum-frame", style: .summaryFrame)` containing a `Run("note text")`
+- **WHEN** an author writes `Summary(id: "ch1-summary") { "note text" }`
+- **THEN** the op log contains, in order: `beginComponent(type: "Summary", id: "ch1-summary")`, `appendParagraph(in: "ch1-summary", id: "sum-frame", style: "summaryFrame")`, `setRuns(target: "sum-frame", runs: [{text: "note text"}])`, `endComponent(id: "ch1-summary")` (canonical names per `ooxml-operation-log`)
+
+#### Scenario: reverse direction reconstructs component invocation
+
+- **WHEN** the reverse transcoder reads the op log produced by the previous scenario
+- **THEN** it emits exactly `Summary(id: "ch1-summary") { "note text" }` and MUST NOT emit the flattened `Paragraph(...) { ... }` form
+
+#### Scenario: component metadata produces no OOXML artifact
+
+- **WHEN** the docx is serialised from the op log produced by the first scenario above
+- **THEN** the resulting `word/document.xml` MUST NOT contain any element corresponding to `beginComponent` or `endComponent`
+- **AND** byte-equal round-trip MUST hold for the docx output across multiple component-instance invocations
+
+### Requirement: Special-character inline atoms as standalone children
+
+Tab stops (`Tab()`), line breaks (`Break()`), no-break hyphens (`NoBreakHyphen()`), and other OOXML inline atoms that have no text content and no formatting properties MUST be expressible as standalone children within the paragraph result builder, parallel to `Run` and `String`. They MUST NOT be modeled as static factory methods on `Run`.
+
+#### Scenario: Tab and Break compose with Run and String
+
+- **WHEN** a paragraph body contains `"Header"; Tab(); "Right-aligned"; Break(); "Continued"`
+- **THEN** the emitted operations include the runs and, between them, `insertTab` / `insertBreak` ops in declaration order (canonical shapes in `ooxml-operation-log`)
+
+##### Example: standalone atom op shapes
+
+| Source | Emitted op (canonical, per `ooxml-operation-log`) |
+| ------ | ------------------------------------------------- |
+| `Tab()` | `insertTab(in: <container-id>)` — appended in declaration order |
+| `Break()` | `insertBreak(in: <container-id>)` |
+| `NoBreakHyphen()` | `insertNoBreakHyphen(in: <container-id>)` |

--- a/openspec/changes/word-aligned-state-sync/specs/ooxml-operation-log/spec.md
+++ b/openspec/changes/word-aligned-state-sync/specs/ooxml-operation-log/spec.md
@@ -132,9 +132,25 @@ This spec is the single normative home of the operation wire format. Other specs
 - **WHEN** a new operation targeting run content is added
 - **THEN** its name and payload reference the OOXML element vocabulary (`run` ↔ `<w:r>`, `tab` ↔ `<w:tab>`, `styleId` ↔ `<w:pStyle w:val>`), not invented synonyms
 
+##### Example: OOXML-mirror correspondence table
+
+| Op / payload field | OOXML anchor (ECMA-376 WordprocessingML) |
+| --- | --- |
+| `appendParagraph` / `insertParagraphAfter` target | `<w:p>` as child of `<w:body>` (or container) |
+| `paraId` (ParagraphPayload) | `w14:paraId` attribute |
+| `setRuns` | `<w:r>` children of `<w:p>` |
+| `bold` (RunPayload) | `<w:b>` (§17.3.2.1 "b (Bold)") |
+| `italic` (RunPayload) | `<w:i>` (§17.3.2.16, ECMA title "Italics"; field spelled `italic` for cross-payload consistency with the shipped `RunFormatPayload.italic`) |
+| `color` (RunPayload) | `<w:color w:val>` |
+| `styleId` | `<w:pStyle w:val>` reference / `<w:style w:styleId>` definition |
+| `insertTab` | `<w:tab/>` (§17.3.3.24) inside `<w:r>` |
+| `insertBreak` | `<w:br/>` (§17.3.3.1) inside `<w:r>` |
+| `insertNoBreakHyphen` | `<w:noBreakHyphen/>` (§17.3.3.18) inside `<w:r>` |
+| `beginComponent` / `endComponent` | (none — documented exception: op-log metadata) |
+
 ### Requirement: AppendParagraph anchors construction-order inserts
 
-The taxonomy SHALL include `appendParagraph(in: ElementID?, paragraph: ParagraphPayload)` appending a paragraph as the last block-level child of the container addressed by `in` (`nil` = the document body). This covers the authoring case where no preceding sibling exists yet; subsequent construction-order inserts SHALL use the existing `insertParagraphAfter(after:)` anchored on the previously emitted element. Addressing stays ID-based — no positional index parameter exists (per the "ID-based operations, never positional indices" requirement; `mdocx-grammar` example indices are derived display metadata, not addressing).
+The taxonomy SHALL include `appendParagraph(in: ElementID?, paragraph: ParagraphPayload)` appending a paragraph as the last block-level child of the container addressed by `in` (`nil` = the document body). This covers the authoring case where no preceding sibling exists yet; subsequent construction-order inserts SHALL use the existing `insertParagraphAfter(after:)` anchored on the previously emitted element. To carry the DSL's mandatory explicit identifiers (`mdocx-grammar` "Mandatory explicit identifiers on structural elements"), `ParagraphPayload` SHALL gain an optional `paraId` field (↔ `w14:paraId`); when present the reducer stamps it on the created `<w:p>`, when absent the existing opID-derived libraryUUID behavior applies unchanged. Addressing stays ID-based — no positional index parameter exists (per the "ID-based operations, never positional indices" requirement; `mdocx-grammar` example indices are derived display metadata, not addressing).
 
 #### Scenario: First paragraph in an empty body
 
@@ -144,7 +160,7 @@ The taxonomy SHALL include `appendParagraph(in: ElementID?, paragraph: Paragraph
 
 ### Requirement: SetRuns replaces inline content with typed run payloads
 
-The taxonomy SHALL include `setRuns(target: ElementID, runs: [RunPayload])` replacing the addressed paragraph's inline content. `RunPayload` formatting fields SHALL mirror `<w:rPr>` children: `bold` ↔ `<w:b>`, `italics` ↔ `<w:i>`, `color` ↔ `<w:color w:val>`.
+The taxonomy SHALL include `setRuns(target: ElementID, runs: [RunPayload])` replacing the addressed paragraph's inline content. The formatting fields SHALL be added to the existing `RunPayload` struct (which today carries only `text`) — NOT to the separate `RunFormatPayload` used by `setRunFormat` — as optionals: `bold` ↔ `<w:b>`, `italic` ↔ `<w:i>`, `color` ↔ `<w:color w:val>`. Spelling note: ECMA-376 titles `<w:i>` "Italics", but the field is spelled `italic` for cross-payload consistency with the shipped `RunFormatPayload.italic` (the OOXML anchor is the element `<w:i>` itself, which both spellings mirror).
 
 #### Scenario: Formatted runs round-trip through the log
 
@@ -171,7 +187,7 @@ The taxonomy SHALL include `beginComponent(type: String, id: ElementID)` / `endC
 
 ### Requirement: Inline atom ops mirror OOXML empty elements
 
-The taxonomy SHALL include `insertTab(in: ElementID)`, `insertBreak(in: ElementID)`, and `insertNoBreakHyphen(in: ElementID)` appending the corresponding empty inline element (`<w:tab/>`, `<w:br/>`, `<w:noBreakHyphen/>`) to the addressed run container in construction order. No index parameter (same ID-based rule as AppendParagraph).
+The taxonomy SHALL include `insertTab(in: ElementID)`, `insertBreak(in: ElementID)`, and `insertNoBreakHyphen(in: ElementID)` appending the corresponding empty inline element (`<w:tab/>`, `<w:br/>`, `<w:noBreakHyphen/>`) in construction order. `in:` SHALL address a **run** (`<w:r>`) — these atoms are only schema-valid inside `<w:r>`, never as direct children of `<w:p>`. When the DSL emits a standalone atom with no preceding run in the paragraph, the reducer SHALL synthesize an empty wrapping `<w:r>` first. No index parameter (same ID-based rule as AppendParagraph). Scope note: a bare `<w:br/>` is the text-wrapping line break; page/column breaks (`w:type="page|column"`) are out of scope until a future additive `type:` parameter.
 
 #### Scenario: Tab op appends w:tab
 

--- a/openspec/changes/word-aligned-state-sync/specs/ooxml-operation-log/spec.md
+++ b/openspec/changes/word-aligned-state-sync/specs/ooxml-operation-log/spec.md
@@ -120,3 +120,60 @@ Log readers SHALL ignore unknown op_type values without crashing, and SHALL pres
 
 - **WHEN** a log file contains a line with `op_type: "future_op_v2"` and the current library does not recognize it
 - **THEN** the line round-trips through read-then-write byte-equal; the operation is treated as opaque (replay leaves the tree unchanged for that op)
+
+### Requirement: Authoring operations extend the taxonomy additively with OOXML-mirror naming
+
+Operations required by the `.mdocx` authoring surface (`mdocx-grammar`) SHALL be added to the `Operation` enum additively: existing cases and their JSONL wire shapes SHALL NOT change. New operation names and payload field names SHALL mirror official OOXML (ECMA-376 WordprocessingML) vocabulary where a correspondence exists — the same naming policy `mdocx-grammar` mandates for DSL elements, extended to the op layer (#128). Ops with no OOXML correspondence SHALL be documented as explicit exceptions with justification.
+
+This spec is the single normative home of the operation wire format. Other specs (`mdocx-grammar`, `ooxml-script-transcode`) SHALL reference operations by canonical name and SHALL NOT restate their shapes.
+
+#### Scenario: New op names anchor to ECMA-376 vocabulary
+
+- **WHEN** a new operation targeting run content is added
+- **THEN** its name and payload reference the OOXML element vocabulary (`run` ↔ `<w:r>`, `tab` ↔ `<w:tab>`, `styleId` ↔ `<w:pStyle w:val>`), not invented synonyms
+
+### Requirement: AppendParagraph anchors construction-order inserts
+
+The taxonomy SHALL include `appendParagraph(in: ElementID?, paragraph: ParagraphPayload)` appending a paragraph as the last block-level child of the container addressed by `in` (`nil` = the document body). This covers the authoring case where no preceding sibling exists yet; subsequent construction-order inserts SHALL use the existing `insertParagraphAfter(after:)` anchored on the previously emitted element. Addressing stays ID-based — no positional index parameter exists (per the "ID-based operations, never positional indices" requirement; `mdocx-grammar` example indices are derived display metadata, not addressing).
+
+#### Scenario: First paragraph in an empty body
+
+- **GIVEN** an empty document body and an empty log
+- **WHEN** the DSL emits its first paragraph
+- **THEN** the op is `appendParagraph(in: nil, paragraph: ...)`; the second paragraph emits `insertParagraphAfter(after: <first-id>)`
+
+### Requirement: SetRuns replaces inline content with typed run payloads
+
+The taxonomy SHALL include `setRuns(target: ElementID, runs: [RunPayload])` replacing the addressed paragraph's inline content. `RunPayload` formatting fields SHALL mirror `<w:rPr>` children: `bold` ↔ `<w:b>`, `italics` ↔ `<w:i>`, `color` ↔ `<w:color w:val>`.
+
+#### Scenario: Formatted runs round-trip through the log
+
+- **WHEN** `setRuns(target: p, runs: [{text: "本章探討"}, {text: "意識本質", bold: true}])` replays
+- **THEN** the paragraph contains two `<w:r>` children in order, the second carrying `<w:rPr><w:b/></w:rPr>`
+
+### Requirement: DefineStyle registers style definitions once
+
+The taxonomy SHALL include `defineStyle(payload: StylePayload)` carrying `styleId` (↔ `<w:style w:styleId>`) plus properties. Replaying a `defineStyle` whose `styleId` already exists SHALL be an idempotent no-op (define-on-first-use semantics from `mdocx-grammar` stay replay-safe).
+
+#### Scenario: Duplicate defineStyle is idempotent
+
+- **WHEN** two `defineStyle(styleId: "titleBrown", ...)` ops replay
+- **THEN** styles.xml contains exactly one `titleBrown` definition and replay does not throw
+
+### Requirement: Component envelope ops are log metadata only
+
+The taxonomy SHALL include `beginComponent(type: String, id: ElementID)` / `endComponent(id: ElementID)` bracketing a `WordComponent` expansion. **Documented exception to OOXML-mirror naming**: these have no OOXML correspondence by design — they are op-log metadata (like the batch markers) and SHALL produce zero elements in serialized OOXML; the reducer treats them as no-ops.
+
+#### Scenario: Envelope produces no OOXML artifact
+
+- **WHEN** a log containing a `beginComponent`/`endComponent` pair replays and the tree serializes
+- **THEN** the output contains no element corresponding to either op
+
+### Requirement: Inline atom ops mirror OOXML empty elements
+
+The taxonomy SHALL include `insertTab(in: ElementID)`, `insertBreak(in: ElementID)`, and `insertNoBreakHyphen(in: ElementID)` appending the corresponding empty inline element (`<w:tab/>`, `<w:br/>`, `<w:noBreakHyphen/>`) to the addressed run container in construction order. No index parameter (same ID-based rule as AppendParagraph).
+
+#### Scenario: Tab op appends w:tab
+
+- **WHEN** `insertTab(in: <run-id>)` replays
+- **THEN** the addressed `<w:r>` gains a trailing `<w:tab/>` child

--- a/openspec/changes/word-aligned-state-sync/specs/ooxml-script-transcode/spec.md
+++ b/openspec/changes/word-aligned-state-sync/specs/ooxml-script-transcode/spec.md
@@ -1,5 +1,11 @@
 ## ADDED Requirements
 
+> Scope note (#128): the operation wire format's normative home is
+> `ooxml-operation-log` — this spec references canonical op names and does
+> not restate their shapes. The script surface conforms to `mdocx-grammar`
+> (per design Decision 9); the pre-mdocx draft shapes formerly used in the
+> scenarios below (`Document.create()` / raw-string styles) are superseded.
+
 ### Requirement: Operation log to Swift script export
 
 The library SHALL provide `ScriptExporter.exportSwift(log:)` that emits a runnable Swift source file whose execution against an empty `OperationLog` reproduces the input log byte-equal.
@@ -8,7 +14,7 @@ The library SHALL provide `ScriptExporter.exportSwift(log:)` that emits a runnab
 
 - **GIVEN** an `OperationLog` containing operations
 - **WHEN** `exportSwift(log:)` runs
-- **THEN** the returned String compiles as a Swift source file with `import OOXMLSwift` and a top-level `func buildDocument() -> Document` that performs the operations
+- **THEN** the returned String compiles as a Swift source file with `import WordDSLSwift` and a top-level `let document = WordDocument { ... }` declaration conforming to `mdocx-grammar`, whose execution emits the operations
 
 #### Scenario: Round-trip log → script → log preserves operations
 
@@ -22,19 +28,19 @@ The library SHALL provide `ScriptImporter.parse(source:)` that reads a Swift sou
 
 #### Scenario: Hand-written script imports successfully
 
-- **GIVEN** a Swift script:
+- **GIVEN** a Swift script (mdocx-grammar canonical form):
   ```swift
-  import OOXMLSwift
-  func buildDocument() -> Document {
-      let doc = Document.create()
-      doc.body.appendParagraph("Title", style: "Heading1")
-      doc.body.appendParagraph("Body intro")
-      doc.body.appendTable(rows: 3, cols: 4)
-      return doc
+  import WordDSLSwift
+
+  let document = WordDocument {
+      Section(id: "main") {
+          Paragraph(id: "p-title", style: .heading1) { "Title" }
+          Paragraph(id: "p-intro") { "Body intro" }
+      }
   }
   ```
 - **WHEN** `ScriptImporter.parse(source:)` runs
-- **THEN** the returned log contains operations equivalent to `[CreateDocument, InsertParagraphAfter("Title", "Heading1"), InsertParagraphAfter("Body intro"), InsertTable(rows:3, cols:4)]`
+- **THEN** the returned log contains operations equivalent to `[defineStyle(heading1), appendParagraph(in: nil, "Title", styleId: "Heading1"), insertParagraphAfter(after: p-title, "Body intro")]` (canonical names per `ooxml-operation-log`)
 
 #### Scenario: Malformed script raises structured error
 
@@ -43,11 +49,11 @@ The library SHALL provide `ScriptImporter.parse(source:)` that reads a Swift sou
 
 ### Requirement: Build a docx end-to-end from a Swift script
 
-The library SHALL support construction of a complete docx file from a Swift script with no prior docx as input. `Document.create()` SHALL initialize an empty document; subsequent typed operations populate the document; `Document.save(to:)` writes the resulting docx.
+The library SHALL support construction of a complete docx file from a Swift script with no prior docx as input. An empty `WordDocument { }` declaration SHALL initialize an empty document; the script body populates it; `WordDocument.save(to:)` writes the resulting docx (atomic three-file write per `mdocx-grammar`).
 
 #### Scenario: Empty document save produces valid docx
 
-- **WHEN** `Document.create().save(to: url)` runs
+- **WHEN** `WordDocument { }.save(to: url)` runs
 - **THEN** the resulting `url` is a valid docx readable by Word: `[Content_Types].xml`, `_rels/.rels`, `word/_rels/document.xml.rels`, `word/document.xml` are all present and well-formed
 
 #### Scenario: Script-built docx round-trips byte-equal

--- a/openspec/changes/word-aligned-state-sync/tasks.md
+++ b/openspec/changes/word-aligned-state-sync/tasks.md
@@ -67,6 +67,18 @@ Implements **Decision 6: Word-import diff via structural element-identity matchi
 - [x] 4.9 Run the rsid-only-no-edit fixture pair: the import diff must produce an empty op set (regression-pin **identity-noise normalization for diff comparison**)
 - [x] 4.10 Tag and release `ooxml-swift v0.33.0`
 
+## 4b. Phase 3.5 — Operation taxonomy alignment (#128, gates Phase 4)
+
+Spec-side consolidation shipped by the #128 PR (op-log delta + transcode scenario rewrite + mdocx-grammar MODIFIED delta). The tasks below are the ooxml-swift implementation side — additive only, per the "Authoring operations extend the taxonomy additively with OOXML-mirror naming" requirement.
+
+- [ ] 4b.1 Extend `Operation` enum with the authoring cases per the updated `ooxml-operation-log` delta: `appendParagraph(in:)`, `setRuns`, `defineStyle`, `beginComponent`/`endComponent`, `insertTab`/`insertBreak`/`insertNoBreakHyphen` (TDD; names + payload fields OOXML-mirror audited). **Verify**: enum cases compile; each constructs and pattern-matches.
+
+- [ ] 4b.2 [P] JSONL codec cases for the new ops + forward-compat round-trip tests (unknown-op preservation unchanged). **Verify**: encode/decode round-trip per op; existing JSONL tests untouched and green.
+
+- [ ] 4b.3 [P] Reducer cases: `beginComponent`/`endComponent` as no-op markers (batch-marker pattern); `appendParagraph`/`setRuns`/`defineStyle`/inline atoms materialize per their spec scenarios incl. defineStyle idempotency. **Verify**: `swift test --filter OperationReducer` green with new cases.
+
+- [ ] 4b.4 Tag and release `ooxml-swift v0.33.1` (additive; sidecar wire format backward-compatible). **Verify**: tag pushed; che-word-mcp suite green against it.
+
 ## 5. Phase 4 — Script transcoder (target v0.34.0)
 
 Implements the `ooxml-script-transcode` capability per Decision 9: Phase 4 script transcoder targets the `mdocx-grammar` contract. Output of `ScriptExporter` MUST conform to `openspec/specs/mdocx-grammar/spec.md`; input of `ScriptImporter` MUST accept exactly that surface. The 14 empty Swift files at `packages/ooxml-swift/Sources/WordDSLSwift/` (placeholders landed by `mdocx-syntax`) are the implementation targets.


### PR DESCRIPTION
Refs #128

## Summary

word-aligned-state-sync Phase 4 動工前發現 operation taxonomy 在三份 spec 中有三個互不相容的版本。本 PR 按 #128 的整合決策收斂：

- **`ooxml-operation-log` delta**（+6 ADDED requirements，純 append）：authoring ops（`appendParagraph(in:)` / `setRuns` / `defineStyle` / `beginComponent`+`endComponent` / 三個 inline atoms），命名與 payload 欄位錨定 ECMA-376 WordprocessingML（含整合對照表）；`beginComponent`/`endComponent` 明文標為無 OOXML 對應的 log-metadata exception；ID-based 定址維持（無 positional index）
- **`ooxml-script-transcode`**：pre-mdocx 草稿 scenarios（`Document.create()` / raw-string style）改寫為 mdocx-grammar surface；scope note 宣告 op-log 為 wire format 唯一 normative home
- **`mdocx-grammar` MODIFIED delta**：SBE op 名 normalize 到 canonical；`at:` index 重新歸類為 derived display metadata；discrepancy 解決順序 pin 死
- **tasks.md §4b**：4 個 ooxml-swift 實作 tasks（enum/JSONL/reducer/release，additive）gating Phase 4
- **design.md**：Decision 9 taxonomy-alignment 注記

Swift 實作端刻意不在本 PR（跨 repo；由 §4b tasks 承接）。

## Verification

Round 1：2 個獨立 lens agents（coverage / OOXML-correctness）+ 主 loop consistency 補跑（第三 agent 因 API session limit degraded，已於 verify comment 誠實記錄）。**0 blocking**；8 advisory 中 6 個已修（`9b19543`），2 個記錄不擋。詳見 #128 的 Verify Report comment。

## Checklist
- [x] Diagnose ✓（Complexity: Plan；Plan deliberation skipped under unattended mode）
- [x] Implement（2 commits）
- [x] Verify ✓（verify-gated PASS）
- [x] `spectra validate word-aligned-state-sync` ✓ valid

## Related
- #127（word-aligned-state-sync tracking）— Phase 4 前置
- PsychQuant/issue #128 的 2 個未修 advisory 屬未來 additive follow-up（numbering/section ops、既有 positional cases 清理）

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer**（Closes/Fixes/Resolves）— IDD 紀律要求 merge 後手動 /idd-close。