### PR TITLE
refactor(cli): macdoc ocr → deprecation shim，通用文字辨識移交 bestOCR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,13 +164,12 @@ swift run macdoc config ai detect
 swift run macdoc config ai list
 swift run macdoc config ai set agent claude
 
-# OCR 設定管理（v1.1+：具名 host profile）
+# OCR 設定管理（v1.1+：具名 host profile；供 pdf-to-latex 內部頁級 OCR 使用）
 swift run macdoc config ocr list
 swift run macdoc config ocr add-host kyle localhost:11435  # 例：SSH tunnel 到遠端 Ollama
-swift run macdoc config ocr add-host local localhost:11434
-swift run macdoc config ocr set-default kyle              # 之後 ocr 命令不傳 --host 就用這個
-swift run macdoc config ocr set-model glm-ocr
-# 之後 `macdoc ocr file.pdf` 自動用 kyle profile，--host 也接受 profile 名
+swift run macdoc config ocr set-default kyle
+# 注意：通用文字辨識入口 `macdoc ocr` 已移除（#145），改用 bestocr——
+# 此處設定只影響 pdf-to-latex 管線內部的頁級 OCR
 
 # 建構個別套件
 cd packages/ooxml-swift && swift build
@@ -378,7 +377,7 @@ swift build
 - `Sources/MacDocCLI/MacDoc+Word.swift` - `macdoc word reverse <docx> --to-mdocx <out> [--from-oplog] [--force] [--coverage] [--paragraphs-only] [--slot name=paraId]…`（docx → `.mdocx.swift` 腳本反向轉換；transcoder 本體在 ooxml-swift 的 `ScriptExporter`/`ScriptImporter`）。**預設 full-fidelity**（format-alignment-engine Phase C #130）：全 parts 騎在腳本上（raw channel byte-equal floor）+ typed DSL 升級（`ReverseExtractor` 的 trial-rebuild byte-equal gate 通過才升級，涵蓋 run rPr / paragraph pPr / sections / canonical tables 五層）；執行腳本重建出 Stage B byte-equal 的 docx。**真實 Word 文件的 document.xml 現在會升級**（word-canonical-forms #131，ooxml-swift v1.4.0）：新增 Word-canonical 詞彙（root namespace 雲、rsid 家族、`xml:space`、inline passthrough markers（bookmark/proofErr）、pPr/rPr 長尾、docGrid/section-type/pgSz、CRLF prolog）後，`90_template_ja.docx`（JPA 日文學術 template）的 document.xml 由 0% 升到 **per-part 100%**（aggregate 53.5%，餘量為尚無 typed 表示的 sibling parts）。`--paragraphs-only` 退回舊的段落 text+styleId 反向（無 byte-equal 保證）；有 oplog sidecar 時仍優先匯出現況 log。`--coverage` 印出 dual-track 覆蓋率報告：每個 part 的 DSL/raw split + aggregate %（DSL 份額 = byte-equal 證明過的 typed 重建；raw = 逐字搬運；基線數字見 [docs/format-alignment-baselines.md](docs/format-alignment-baselines.md)）。`--slot name=paraId`（可重複，Phase D + #131）：指定段落的文字成為腳本的 Swift 函式參數；**DSL-spellable 段落**走 script-text 參數，**raw-form 格式化段落**（真實 template 常見）走 op-level 替換（`// @slot` directive + 替換 `setRuns` run text），兩者都 strict mode 明確指定、不推斷；無 slot 時腳本逐字重建 byte-equal。**能拼寫 ≠ 理解渲染效果**（render-effect-semantics 第三層）：typed 欄位對排版的實際效果由 [docs/render-effect-registry.md](docs/render-effect-registry.md) 台帳記錄——每條 entry 須經 gated perturbation probe（`RUN_WORD_INTEGRATION=1 swift test --filter RenderEffectProbeTests`，真實 Word 渲染 + PDFKit 幾何量測）驗證方標 `verified`（no probe, no claim）；slot 換內容另有渲染驗收（RealTemplateUpgradeTests scenario (d)：頁數/頁框/被替換頁行距結構不變、未動頁 pixel-equal）
 - `Sources/MacDocCLI/MacDoc+Convert.swift` - Convert 統一轉換入口（16 路由，textutil-compatible）
 - `Sources/MacDocCLI/MacDoc+PDF.swift` - PDF 子命令（簡化 pipeline: ocr + Phase 2 consolidation）
-- `Sources/MacDocCLI/MacDoc+OCR.swift` - OCR 子命令（top-level `macdoc ocr`，單檔 GLM-OCR）
+- `Sources/MacDocCLI/MacDoc+OCR.swift` - deprecation shim（#145）：`macdoc ocr` 已移除，印遷移訊息指向 bestocr 並以 exit 2 結束。通用文字辨識歸 PsychQuant/bestOCR 單點；pdf-to-latex 內部頁級 OCR（PageOCRRunner）不受影響，其委派屬第二期（bestOCR#55 介面定案後）
 - `Sources/MacDocCLI/MacDoc+Bib.swift` - Bib 子命令（.bib → APA 7 HTML/Markdown，支援 --key 過濾）
 - `Sources/MacDocCLI/MacDoc+Config.swift` - Config 子命令（AI 設定管理）
 

--- a/Sources/MacDocCLI/MacDoc+OCR.swift
+++ b/Sources/MacDocCLI/MacDoc+OCR.swift
@@ -1,110 +1,42 @@
 import ArgumentParser
 import Foundation
-import OCRCore
-import PDFToLaTeXCore
 
 extension MacDoc {
+    /// Deprecation shim（macdoc#145，2026-08-07）。
+    ///
+    /// 通用文字辨識的所有權歸 bestOCR（PsychQuant/bestOCR）單點：引擎選擇、
+    /// 版本紀錄、evidence 慣例都在那邊維護。本子命令原本自帶完整 OCR 路徑
+    /// （ollama/mlx backend、glm-ocr 模型管理），與 bestOCR 完全重疊——同一台
+    /// 機器兩套入口各自演進，最後一定分岔。
+    ///
+    /// 保留 shim 而非直接移除：既有腳本呼叫 `macdoc ocr` 時拿到明確的遷移
+    /// 指引與非零退出碼，而不是 `unknown subcommand`。下一個 major 版整個刪除。
+    ///
+    /// 注意：pdf-to-latex 管線內部的頁級 OCR（PageOCRRunner）不在此列——那是
+    /// 管線零件不是通用辨識入口，其委派 bestOCR 屬第二期，前置是
+    /// PsychQuant/bestOCR#55 定義的委派介面。
     struct OCR: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "ocr",
-            abstract: "VLM OCR（PDF 和圖片 → 文字，支援 MLX 本地 / Ollama）"
+            abstract: "（已移除）文字辨識改用 bestocr — PsychQuant/bestOCR"
         )
 
-        @Argument(help: "輸入檔案（PDF、PNG、JPG）")
-        var input: String
-
-        @Option(name: .long, help: "輸出檔案路徑（預設 stdout）")
-        var output: String?
-
-        @Option(name: .long, help: "PDF 頁碼範圍（例如 1-3）")
-        var pages: String?
-
-        @Option(name: .long, help: "OCR 後端：ollama 或 mlx（預設讀 config，再 fallback ollama）")
-        var backend: String?
-
-        @Option(name: .long, help: "模型名稱（預設讀 config，再 fallback glm-ocr / mlx-community/Qwen3-VL-4B-Instruct-4bit）")
-        var model: String?
-
-        @Option(name: .long, help: "Ollama 伺服器地址或 host profile 名稱（預設用 config 的 default host）")
-        var host: String?
-
-        @Option(name: .long, help: "最大生成 token 數")
-        var maxTokens: Int = 4096
+        @Argument(parsing: .allUnrecognized, help: .hidden)
+        var ignored: [String] = []
 
         func run() async throws {
-            let inputURL = try validatedInputURL(input)
+            let message = """
+            `macdoc ocr` 已移除（macdoc#145）。
 
-            let pageRange: ClosedRange<Int>?
-            if let pages {
-                pageRange = try parsePageRange(pages)
-            } else {
-                pageRange = nil
-            }
+            文字辨識改用 bestOCR：
+              bestocr ocr <input>            # 單檔 OCR
+              bestocr recommend              # 不確定用哪個引擎時
+              bestocr consensus <input>      # 高價值文件的多引擎互核
 
-            // Load config (沒設定檔也 OK，會回傳預設值)
-            let config = (try? AIConfig.load()) ?? AIConfig()
-
-            // Resolve backend: --backend > config.ocrDefaultBackend > "ollama"
-            let resolvedBackend = backend ?? config.ocrDefaultBackend
-
-            // Build backend
-            let ocrBackend: any OCRBackend
-            switch resolvedBackend {
-            case "ollama":
-                let modelName = model ?? config.ocrDefaultModel
-                let resolvedHost = config.resolveOCRHost(host)
-                FileHandle.standardError.write(
-                    Data("使用 Ollama 後端（\(resolvedHost), 模型: \(modelName)）\n".utf8))
-                ocrBackend = OllamaBackend(host: resolvedHost, model: modelName)
-
-            case "mlx":
-                let repo = model ?? (config.ocrDefaultModel == "glm-ocr"
-                    ? "mlx-community/Qwen3-VL-4B-Instruct-4bit"
-                    : config.ocrDefaultModel)
-                FileHandle.standardError.write(Data("正在載入模型 \(repo)...\n".utf8))
-                ocrBackend = try await MLXBackend.load(
-                    repo: repo, maxTokens: maxTokens
-                ) { filename, progress in
-                    let percent = Int(progress * 100)
-                    FileHandle.standardError.write(
-                        Data("\r下載: \(filename) (\(percent)%)".utf8))
-                }
-                FileHandle.standardError.write(Data("\n模型載入完成\n".utf8))
-
-            default:
-                throw ValidationError("未知的後端: \(resolvedBackend)（支援: ollama, mlx）")
-            }
-
-            // Run OCR
-            let pipeline = OCRPipeline(backend: ocrBackend)
-
-            let result = try await pipeline.processFile(
-                path: inputURL.path,
-                pageRange: pageRange
-            ) { current, total in
-                FileHandle.standardError.write(
-                    Data("\r處理頁面 \(current)/\(total)".utf8))
-            }
-
-            if pageRange != nil {
-                FileHandle.standardError.write(Data("\n".utf8))
-            }
-
-            try writeStringOutput(result, to: output)
-        }
-
-        private func parsePageRange(_ rangeStr: String) throws -> ClosedRange<Int> {
-            let parts = rangeStr.split(separator: "-").map(String.init)
-            if parts.count == 1, let page = Int(parts[0]) {
-                return page...page
-            } else if parts.count == 2, let start = Int(parts[0]), let end = Int(parts[1]) {
-                guard start <= end else {
-                    throw ValidationError("頁碼範圍無效: \(rangeStr)（起始頁必須 ≤ 結束頁）")
-                }
-                return start...end
-            } else {
-                throw ValidationError("頁碼範圍格式無效: \(rangeStr)（應為 N 或 N-M）")
-            }
+            安裝與說明：https://github.com/PsychQuant/bestOCR
+            """
+            FileHandle.standardError.write(Data((message + "\n").utf8))
+            throw ExitCode(2)
         }
     }
 }

--- a/plugins/macdoc/skills/macdoc/SKILL.md
+++ b/plugins/macdoc/skills/macdoc/SKILL.md
@@ -3,9 +3,9 @@ name: macdoc
 description: |
   macOS 原生文件處理 CLI 工具的使用指南。
   當需要做格式轉換（SRT→HTML、MD→HTML、DOCX→MD）、
-  VLM OCR（PDF/圖片→文字）、或 SRT 逐字稿處理時使用。
-  觸發詞：「macdoc」「轉換格式」「OCR」「逐字稿轉HTML」
-  「手寫筆記辨識」「PDF轉文字」
+  或 SRT 逐字稿處理時使用。文字辨識（OCR）已移交 bestOCR（macdoc#145），
+  提到 OCR 時請改用 bestocr 相關 skill。
+  觸發詞：「macdoc」「轉換格式」「逐字稿轉HTML」
 ---
 
 # macdoc — macOS 原生文件處理 CLI
@@ -18,7 +18,7 @@ description: |
 | 子命令 | 用途 | 常用場景 |
 |--------|------|---------|
 | `convert` | 格式轉換 | SRT→HTML、MD→HTML、DOCX→MD |
-| `ocr` | VLM OCR | PDF/圖片→文字（手寫筆記辨識） |
+| `ocr` | （已移除 #145）| 文字辨識改用 bestocr |
 | `config` | 設定管理 | AI CLI 工具、OCR host/model 預設值 |
 | `pdf` | PDF→LaTeX | 學術 PDF 處理（較少用） |
 | `bib` | BibLaTeX→APA | 參考文獻格式轉換 |
@@ -103,171 +103,19 @@ macdoc convert --to md --output output.md input.docx
 
 ---
 
-## ocr — VLM OCR
+## ocr —（已移除，改用 bestOCR）
+
+`macdoc ocr` 已於 2026-08-07 移除（macdoc#145）：通用文字辨識的所有權歸
+bestOCR（PsychQuant/bestOCR）單點——引擎選擇、版本紀錄、evidence 慣例都在
+那邊維護。現在執行 `macdoc ocr` 會印遷移訊息並以 exit 2 結束。
 
 ```bash
-macdoc ocr <input> [options]
+bestocr ocr <input>            # 單檔 OCR
+bestocr recommend              # 不確定用哪個引擎時
+bestocr consensus <input>      # 高價值文件的多引擎互核
 ```
 
-用 Vision Language Model 做 OCR，支援手寫筆記、印刷文件、截圖。
-
-### Backend 選擇
-
-| Backend | 選項 | 說明 |
-|---------|------|------|
-| **Ollama**（預設） | `--backend ollama` | 透過 Ollama HTTP API，需要先啟動 Ollama |
-| **MLX**（本地） | `--backend mlx` | 用 mlx-swift-lm 本地推理（⚠️ 目前有 upstream bug） |
-
-### Ollama host 設定（v1.1+）
-
-**推薦流程**：用 `config ocr` 設定好 host profile，之後就不用每次傳 `--host`。
-
-```bash
-# 一次性設定（本機或遠端 Kyle）
-macdoc config ocr add-host kyle localhost:11435   # 先建 SSH tunnel 到 kyle
-macdoc config ocr add-host local localhost:11434  # 本機 Ollama
-macdoc config ocr set-default kyle                # 設為預設
-
-# 之後直接 OCR，不用 --host
-macdoc ocr handwritten.pdf
-```
-
-**`--host` 解析規則**：先當 profile 名查 config，找不到才當原始地址。
-
-```bash
-macdoc ocr file.pdf                       # 用 default profile
-macdoc ocr file.pdf --host local          # 切換到 local profile
-macdoc ocr file.pdf --host 192.168.1.50:11434  # 不是 profile,當原始地址
-```
-
-### SSH tunnel 到 Kyle
-
-Kyle 的 Mac Studio（M4 Max/128GB）上有 Ollama + glm-ocr：
-
-```bash
-# 建 SSH tunnel（Kyle's Ollama 預設只聽 localhost）
-ssh -fN -L 11435:localhost:11434 kyle
-
-# 確認連線
-curl -s http://localhost:11435/api/tags | python3 -m json.tool
-
-# OCR（如果已設 default=kyle）
-macdoc ocr notes.pdf --output notes.md
-
-# 長時間 OCR 記得用 caffeinate 防電腦睡眠（SSH tunnel 會斷）
-caffeinate -i -- macdoc ocr large.pdf --output large.md
-```
-
-### 可用模型
-
-| 模型 | 用途 | --model 值 |
-|------|------|-----------|
-| **glm-ocr**（預設） | 中文手寫/印刷 OCR | `glm-ocr` |
-| qwen3-vl | 多語言 VLM | `qwen3-vl` |
-| minicpm-v | 輕量 VLM | `minicpm-v` |
-
-### 常用範例
-
-```bash
-# 手寫筆記 PDF（指定頁碼）
-macdoc ocr notes.pdf --pages 1-3 --output notes.md
-
-# 大型 PDF 分段 OCR(避免長時間 tunnel 斷線)
-macdoc ocr big.pdf --pages 1-60  --output part1.md
-macdoc ocr big.pdf --pages 61-120 --output part2.md
-cat part1.md part2.md > full.md
-
-# 單張圖片
-macdoc ocr screenshot.png
-
-# 指定模型(覆寫 config default)
-macdoc ocr document.pdf --model qwen3-vl
-```
-
-### 已知問題
-
-- **MLX backend crash**:mlx-swift-lm 有 upstream bug(ml-explore/mlx-swift-lm#191),所有 VLM 模型都會 crash。暫時只能用 Ollama。
-- **SSH tunnel 長時間會斷**:連線超過 2-3 小時會 timeout。解法是分段 OCR(`--pages`)或用 `caffeinate -i`。
-- **大頁面**:超過 8000px 的頁面會被自動縮小。
-
-### 批次與並行(77 PDF 轉學考實戰累積)
-
-當要 OCR 數十張 PDF 或數百頁時,單檔順序跑會花太久。下面是實戰整理出來的 pattern。
-
-#### 為什麼先拆 PNG 再 OCR
-
-直接 `macdoc ocr file.pdf` 在某些 PDF 上會漏頁首 — 模型內部的 PDF→image 路徑可能用低解析度。改成預先用 `pdftoppm` 拆 PNG 再逐頁 OCR,單頁可控、可平行、漏頁可重跑。
-
-```bash
-# Step 1: 拆 PNG (200 DPI 對手寫/印刷都夠)
-mkdir -p out
-pdftoppm -r 200 -png file.pdf out/page
-
-# Step 2: 逐 PNG OCR (見下面 xargs -P pattern)
-
-# Step 3: 合併
-cat out/page-*.md > full.md
-```
-
-#### Ollama 並發環境變數
-
-跑遠端 Ollama(SSH tunnel 連 Kyle 等)時這幾個變數顯著影響吞吐:
-
-| 變數 | 建議 | 說明 |
-|------|------|------|
-| `OLLAMA_NUM_PARALLEL` | 4~8 | 同 model 並發請求數;太高會 OOM |
-| `OLLAMA_MAX_LOADED_MODELS` | 1 | 單 model 任務維持 1,避免 thrash |
-| `OLLAMA_FLASH_ATTENTION` | 1 | Apple Silicon Metal 後端免費加速 |
-
-設定方式:在 Ollama server 端的 `~/Library/LaunchAgents/com.ollama.server.plist` 加 `EnvironmentVariables`,或啟動前 `export`,然後 `ollama serve`。
-
-#### `xargs -P` 並行 pattern
-
-```bash
-# N=4 並行 (對應 OLLAMA_NUM_PARALLEL=4)
-find out -name "page-*.png" | xargs -P 4 -I{} \
-  macdoc ocr {} --output "{}.md" --host kyle --model glm-ocr
-
-# 失敗重試 (找出無 .md 的 png 重跑)
-find out -name "page-*.png" | while read png; do
-  [ -f "${png}.md" ] || echo "$png"
-done | xargs -P 2 -I{} macdoc ocr {} --output "{}.md" --host kyle
-```
-
-#### SSH tunnel 維持
-
-長時間批次 OCR(>2 小時)tunnel 會斷。三種策略:
-
-```bash
-# (a) 簡易 — 跑前重建 tunnel,搭配 caffeinate 防 mac sleep
-ssh -fN -L 11435:localhost:11434 kyle
-caffeinate -i -- xargs -P 4 ... < pages.txt
-
-# (b) autossh — 自動重連
-brew install autossh
-autossh -fN -M 0 -L 11435:localhost:11434 kyle
-
-# (c) Health check loop — 中途斷 tunnel 自動重建
-while true; do
-  curl -s --max-time 5 http://localhost:11435/api/tags >/dev/null \
-    || ssh -fN -L 11435:localhost:11434 kyle
-  sleep 60
-done &
-```
-
-實戰建議:走 (b) autossh + `caffeinate -i`,踩坑成本最低。
-
-#### 與 CLI `--parallel` 的整合(roadmap)
-
-`PsychQuant/macdoc#73` 追蹤把 `--parallel N` 整合進 macdoc CLI(內建 `xargs -P` 邏輯 + 失敗重試 + tunnel health check)。CLI 落地後上面那段 pattern 會被取代成:
-
-```bash
-macdoc ocr-batch out/*.png --parallel 4 --host kyle  # roadmap, 尚未實作
-```
-
-在那之前,沿用 `xargs -P` 即可。另一個正在被討論的方向是新建 `batch-ocr` plugin 把 PDF→PNG→OCR→merge 整個 pipeline 包成 single command,見 PsychQuant/psychquant-claude-plugins#6。
-
----
+pdf-to-latex 管線內部的頁級 OCR 不受影響（那是管線零件，不是通用辨識入口）。
 
 ## config — 設定管理
 
@@ -319,7 +167,7 @@ macdoc config ocr list
 
 | 場景 | 工具組合 |
 |------|---------|
-| 手寫筆記 → TikZ 圖 | `macdoc ocr` → 辨識內容 → 寫 TikZ → `xelatex` 編譯 |
+| 手寫筆記 → TikZ 圖 | `bestocr ocr` → 辨識內容 → 寫 TikZ → `xelatex` 編譯 |
 | SRT → handout 網頁 | `macdoc convert --to html` → `inject-search.py` |
 | PDF 筆記 → PNG | `pdftoppm -png -r 200`（不是 macdoc，是 poppler） |
 | 學生作業 .docx → 閱讀 | 用 che-word-mcp 的 `get_document_text`（不需要 macdoc） |


### PR DESCRIPTION
實作 #145 第一期。

## 改動

| 檔案 | 內容 |
|---|---|
| `Sources/MacDocCLI/MacDoc+OCR.swift` | 110 行 OCR 實作 → deprecation shim：印遷移訊息（bestocr ocr / recommend / consensus + repo 連結）、exit 2；`.allUnrecognized` 吞舊 flag 不二次報錯 |
| `CLAUDE.md` | 架構描述改標 shim；config ocr 註明只影響 pdf-to-latex 內部頁級 OCR |
| `plugins/macdoc/skills/macdoc/SKILL.md` | frontmatter 不再宣稱 OCR 能力（觸發詞刪「OCR」「手寫筆記辨識」「PDF轉文字」）；總覽表、ocr 專節、工作流表改指 bestocr |

## 為什麼 shim 不是刪除

既有腳本呼叫 `macdoc ocr` 時拿到明確的遷移指引與非零退出碼，而不是 `unknown subcommand`。維護成本近零（一個小檔），下個 major 版整個刪除。

## 分期界線（重要）

**pdf-to-latex 內部的頁級 OCR（`PageOCRRunner` + `OCRCore` 依賴）本 PR 不動**——那是管線零件不是通用辨識入口。其委派 bestOCR 屬第二期，前置是 PsychQuant/bestOCR#55 定義的委派介面：介面沒定就動手，等於把管線接到不存在的東西上。`config ocr` 子命令組因此保留（內部管線仍讀取）。

## 驗證

- `swift build --product macdoc` 綠
- shim 實測：印遷移訊息、exit 2、舊 flag（`--backend mlx`）被吞下

Refs #145
